### PR TITLE
Merge develop branch for upydev 0.3.7 release

### DIFF
--- a/ble_repl_cli/bin/blerepl
+++ b/ble_repl_cli/bin/blerepl
@@ -1883,9 +1883,9 @@ def custom_sh_cmd(cmd_inp):
             pass
 
     if cmd_inp.split(' ')[0] == 'vim':
-        print('<-- Vim editor -->')
-        print('Use I to insert; (ESC , :w) to write; (ESC ,:q) to exit')
-        time.sleep(1)
+        # print('<-- Vim editor -->')
+        # print('Use I to insert; (ESC , :w) to write; (ESC ,:q) to exit')
+        # time.sleep(1)
         try:
             file_to_edit = cmd_inp.split(' ')[1]
             lvim = 'vim {}'.format(file_to_edit)
@@ -1900,9 +1900,9 @@ def custom_sh_cmd(cmd_inp):
             pass
 
     if 'emacs' in cmd_inp.split(' ')[0]:
-        print('<-- Emacs editor -->')
-        print('Use Ctrl-x-Ctrl-s to Save,  Ctrl-x-Ctrl-c to exit')
-        time.sleep(1)
+        # print('<-- Emacs editor -->')
+        # print('Use Ctrl-x-Ctrl-s to Save,  Ctrl-x-Ctrl-c to exit')
+        # time.sleep(1)
         try:
             file_to_edit = cmd_inp.split(' ')[1]
             lemacs = 'emacs {} -nw'.format(file_to_edit)

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.7] Unreleased Github Repo [develop]
 ## Added
 - `rssi` command in shell repls to get RSSI value (Wifi or Ble)
+- `make_sgroup` / `mksg` command to create a subgroup of an existant group of devices.
 ## Fix
 - `firmwaretools.get_fw_versions` update after `micropython.org\all` not working anymore.
 - fix device name instead of `None` in `put`, `get`, `fget`, `dsync` in `sslweb_repl` with `-nem` mode enabled.

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.7] Unreleased Github Repo [develop]
+## Fix
+- `firmwaretools.get_fw_versions` update after `micropython.org\all` not working anymore.
 ## [0.3.6] 2021-10-24
 ## Added
 - `zerotier` compatibility through raspberry pi bridge (port forwarding + ufw route rules) and `-zt [HOST IP/BRIDGE IP]` option to indicate host zerotier ip and raspberry pi bridge local ip for ssl

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.7] Unreleased Github Repo [develop]
 ## Fix
 - `firmwaretools.get_fw_versions` update after `micropython.org\all` not working anymore.
+
 ## [0.3.6] 2021-10-24
 ## Added
 - `zerotier` compatibility through raspberry pi bridge (port forwarding + ufw route rules) and `-zt [HOST IP/BRIDGE IP]` option to indicate host zerotier ip and raspberry pi bridge local ip for ssl
@@ -20,6 +21,7 @@ shell-repl mode. Also `-zt` option with config command compatibility.
 - `fget` error on connection, and unintended verbose output on close.
 - `check -i`, `info` commands in `-apmd`, if connected to AP of the device.
 - fix ssl cert authentication in `wss` mode if using `.local`/`dhcp_hostname` target.
+
 ## [0.3.5] 2021-09-09
 ## Fix
 - `set_ntptime` with WebSocket Devices
@@ -75,6 +77,7 @@ shell-repl mode. Also `-zt` option with config command compatibility.
 - `-d ` flag for `dsync` to sync from device to host.
 - `backup` command == `dsync . -d` to make a backup of the device filesystem
 - `rsync` command == `dsync [DIR] -rf -wdl` to recursively sync (deleting files too)
+
 ## [0.3.3] - 2020-06-07
 ### Fix
 - Fix `git status dev` aware of current branch
@@ -82,6 +85,7 @@ shell-repl mode. Also `-zt` option with config command compatibility.
 - Fix `put` for pyboard in SERIAL SHELL-REPL mode
 - Fix `fw` for downloading and flashing firmware to pyboard, esp in SERIAL SHELL-REPL mode, now asserts serial port is available after flashing.
 - Fix `battery` error if command fails.
+
 ## [0.3.2] - 2020-05-27
 ### Fix
 - Fix `set_localtime` for pyboard in SERIAL SHELL-REPL mode
@@ -93,12 +97,15 @@ shell-repl mode. Also `-zt` option with config command compatibility.
 - Fix, `apscan` mode now show MAC address instead of bytes
 ### Added
 - Watch mode with `-wdl` flag for `put -fre` and `d_sync` modes. Uploads only new or modified files
+
 ## [0.3.1] - 2020-04-23
 ### Fix
 - Fix for host ip determination
+
 ## [0.3.0] - 2020-04-13
 ### Fix
 - Minor fix for host ip determination (while ECDSA key is generated and for SSLWebREPL mode)
+
 ## [0.2.9] - 2020-02-24
 ### Added
 - jupyter console integration through jupyter-micropython-upydevice
@@ -107,12 +114,14 @@ shell-repl mode. Also `-zt` option with config command compatibility.
 - autocompletion for zsh
 - git integration and 'git init dev' command for SHELLS
 - sslgen_key command help
+
 ## [0.2.8] - 2020-02-16
 ### Added
 - emacs in nw mode by default
 - tig integration for git workflow: [tig](https://jonas.github.io/tig/)
 ### Fix
 - in SERIAL SHELL-REPL 'fw update' command for esp8266
+
 ## [0.2.7] - 2020-02-08
 ### Added
 - To be able to use this new commands update the SSL key and cert with 'upydev sslgen_key -tfkey' and do 'upydev update_upyutils'
@@ -122,6 +131,7 @@ shell-repl mode. Also `-zt` option with config command compatibility.
 - 'set_wss' upydev command to switch WebREPL to WebSecureREPL and
 'set_wss -wss' to switch back to WebREPL
 - if WebSecureREPL enabled, upydev 'put' and 'get' commands support WebSecureREPL file transfer using '-wss' option e.g. 'upydev put -f foo.py -wss'
+
 ## [0.2.6] 2020-02-02
 ### Added
 - 'bat' command output style configurable and line numbers (inspired by https://github.com/willmcgugan/rich)
@@ -131,9 +141,11 @@ shell-repl mode. Also `-zt` option with config command compatibility.
 - cat, bat in SSLWebREPL if last line does not end with new line ('\\n')
 - ECDSA key (SECP256R1_SHA256 method to meet IETF recommendations)
 - 'git status dev' now tracks all commits (inside or outside the shell)
+
 ## [0.2.5] 2020-01-26
 ### Fix
 - put method in SERIAL SHELL for esp32/8266
+
 ## [0.2.4] - 2020-01-26
 ### Added
 - 'timeit' command to measure execution time of a script/command (for SSL/SERIAL SHELLS)
@@ -146,6 +158,7 @@ shell-repl mode. Also `-zt` option with config command compatibility.
 - Changed upydev 'sslgen_rsakey' to 'sslgen_key' key now is a ECDSA key (SECP384R1 method)
 - Cipher suite is now TLSv1.2 @ ECDHE-ECDSA-AES128-CCM8 - 128 bits which is recommended for constrained devices / IOT (This requires a recent version of python-ssl)
 - put method (faster) in SERIAL SHELL
+
 ## [0.2.3] - 2020-01-19
 ### Added
 - fw , flash (and fw update which is 'fw get' + 'flash') commands for SERIAL SHELL
@@ -160,17 +173,20 @@ e.g. 'upipl' or 'upipl [module]' (SSL/SERIAL SHELLS)
 - 'update_upyutils' command for SERIAL SHELL
 ### Fix
 - fw and flash commands of upydev
+
 ## [0.2.2] 2020-01-13
 ### Added
 - Autocompletion on REPLS (SSL/SERIAL) for "from foo import X" will show option of what to import/autocomplete on match for frozen modules too.
 ### Fix
 - Autocompletion on REPLS (SSL/SERIAL) for "from foo import X" will show option of what to import/autocomplete on match (bug fix)
+
 ## [0.2.1] 2020-01-12
 ### Added
 - Autocompletion on REPLS (SSL/SERIAL) for "from foo import X" will show option of what to import/autocomplete on match
 - CTRL-u deprecated (no encryption toggle), CTRL-p now shows RAM STATUS (used/free)
 - CTRL-e in SHELLS (SSL/SERIAL) moves cursor to end of the line (if not in edit mode)
 - 'batl' command for SHELLS(SSL/SERIAL) to print local file with python syntax highlighting
+
 ## [0.2.0] - 2020-01-10
 ### Added
 - serial terminal SHELL-REPL mode (same style as SSLWebREPL) "sh_srepl"
@@ -180,6 +196,7 @@ e.g. 'upipl' or 'upipl [module]' (SSL/SERIAL SHELLS)
 - ssl_wrepl netscan command for esp8266
 - Add help of latest upydev commands
 - see -c command help info text wraps at terminal length
+
 ## [0.1.9] - 2020-01-07
 ### Added
 - Mode to generate RSA key and self signed certificate ('sslgen_rsakey')
@@ -189,6 +206,7 @@ e.g. 'upipl' or 'upipl [module]' (SSL/SERIAL SHELLS)
 - "ssl@[dev]" shortcut to "ssl_wrepl" mode
 - Progress bar length and percentage fix, and estimated time
 - put and get commands now works in SSL mode too
+
 ## [0.1.8] - 2019-12-29
 ### Added
 - New CryptoWebREPL shell local commands ('lsof', 'l_ifconfig', 'l_ifconfig_t') (last one works only on MacOS, linux pending...). Network utilities
@@ -198,6 +216,7 @@ e.g. 'upipl' or 'upipl [module]' (SSL/SERIAL SHELLS)
 - Paste mode in unencrypted mode
 - Fix -h command error if there is no 'UPY_G.config' global group file
 - Installation dependencies
+
 ## [0.1.7] - 2019-12-24
 ### Added
 - Mode to generate RSA private key, and send it to the device ('gen_rsakey')
@@ -215,6 +234,7 @@ e.g. 'upipl' or 'upipl [module]' (SSL/SERIAL SHELLS)
 ### Fix
 - Progress bar animation now available in put/get/sync modes and auto-adjust to terminal size
 - sync mode improved
+
 ## [0.1.6] - 2019-12-08
 ### Added
 - New 'update_upyutils' mode to update the latest versions of sync_tool.py,
@@ -226,6 +246,7 @@ e.g. 'upipl' or 'upipl [module]' (SSL/SERIAL SHELLS)
 ### Fix
 - BSSID column of netscan command now shows mac address instead of bytes format
 - refactor of sync mode (shows transfer progress animation also)
+
 ## [0.1.5] - 2019-11-23
 ### Added
 - New mode d_sync to sync recursively a directory (all files and subfolders)
@@ -252,6 +273,7 @@ e.g. 'upipl' or 'upipl [module]' (SSL/SERIAL SHELLS)
 
 ### Fix
 - Code refactoring using upydevice
+
 ## [0.1.4] - 2019-11-12
 ### Added
 - New 'upyutils' script 'upylog.py' a modification of logging module to be able to log messages or exceptions to file and two formats to choose ([NAME] [LVL]
@@ -264,6 +286,7 @@ source sd.
 ### Fix
 - Command options -g , -st, -rep, -apmd (do not need any argument, they store true if used)
 - Option "-md local" in diagnose option (deprecated) use -apmd instead
+
 ## [0.1.3] - 2019-11-02
 ### Fix
 - package requests dependency added
@@ -271,15 +294,18 @@ source sd.
 - KeyboardInterrupt command (kbi) to stop for/while loops
 - New mode diagnose
 - New -apmd option to set target to 192.168.4.1 (AP default)
+
 ## [0.1.2] - 2019-10-14
 ### Added
 - '-dir' option to put/get commands to select in which directory to put file or get a file from
+
 ## [0.1.1] - 2019-10-01
 ### Fix
 - Dedent with shift-tab in wrepl (normal mode and paste mode)
 ### Added
 - find command to scan for upy devices in the WLAN
 - WIFI UTILS commands
+
 ## [0.1.0] - 2019-09-19
 ### Fix
 - toggle wrepl in synchronized mode for ssh session
@@ -287,6 +313,7 @@ source sd.
 ### Added
 - toggle autosuggest mode (fish shell like)
 - mg_group command to manage groups to add or remove devices
+
 
 ## [0.0.9] - 2019-08-22
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -4,13 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.7] Unreleased Github Repo [develop]
+## [0.3.8] Unreleased Github Repo [develop]
+## [0.3.7] 2021-12-16
 ## Added
 - `rssi` command in shell repls to get RSSI value (Wifi or Ble)
 - `make_sgroup` / `mksg` command to create a subgroup of an existing group of devices.
 - `set_hostname` command to set hostname of the device for dhcp service (needs *wpa_supplicant.py*)
 - `set_localname` command to set localname of the device for ble gap/advertising name (needs *ble_uart_peripheral.py*)
-- Now `-@` option accepts multiple devices, names with `*` wildcard or global group `gg`
+- Now `-@` option accepts multiple devices, names with `*` wildcard or global group `gg` or other group names, e.g. `upydev check -i -@ esp\* dev{1..4} mytestgroup`
+will expand to all devices that start with `esp` , `dev1 dev2 dev3 dev4` and devices configured in `mytestgroup`
 ## Fix
 - `firmwaretools.get_fw_versions` update after `micropython.org\all` not working anymore.
 - fix device name instead of `None` in `put`, `get`, `fget`, `dsync` in `sslweb_repl` with `-nem` mode enabled.

--- a/changelog.md
+++ b/changelog.md
@@ -5,8 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.3.7] Unreleased Github Repo [develop]
+## Added
+- `rssi` command in shell repls to get RSSI value (Wifi or Ble)
 ## Fix
 - `firmwaretools.get_fw_versions` update after `micropython.org\all` not working anymore.
+- fix device name instead of `None` in `put`, `get`, `fget`, `dsync` in `sslweb_repl` with `-nem` mode enabled.
+- fix `fget` disconnection error.
 
 ## [0.3.6] 2021-10-24
 ## Added

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `make_sgroup` / `mksg` command to create a subgroup of an existing group of devices.
 - `set_hostname` command to set hostname of the device for dhcp service (needs *wpa_supplicant.py*)
 - `set_localname` command to set localname of the device for ble gap/advertising name (needs *ble_uart_peripheral.py*)
+- Now `-@` option accepts multiple devices, names with `*` wildcard or global group `gg`
 ## Fix
 - `firmwaretools.get_fw_versions` update after `micropython.org\all` not working anymore.
 - fix device name instead of `None` in `put`, `get`, `fget`, `dsync` in `sslweb_repl` with `-nem` mode enabled.

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.7] Unreleased Github Repo [develop]
 ## Added
 - `rssi` command in shell repls to get RSSI value (Wifi or Ble)
-- `make_sgroup` / `mksg` command to create a subgroup of an existant group of devices.
+- `make_sgroup` / `mksg` command to create a subgroup of an existing group of devices.
 ## Fix
 - `firmwaretools.get_fw_versions` update after `micropython.org\all` not working anymore.
 - fix device name instead of `None` in `put`, `get`, `fget`, `dsync` in `sslweb_repl` with `-nem` mode enabled.

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - `rssi` command in shell repls to get RSSI value (Wifi or Ble)
 - `make_sgroup` / `mksg` command to create a subgroup of an existing group of devices.
+- `set_hostname` command to set hostname of the device for dhcp service (needs *wpa_supplicant.py*)
+- `set_localname` command to set localname of the device for ble gap/advertising name (needs *ble_uart_peripheral.py*)
 ## Fix
 - `firmwaretools.get_fw_versions` update after `micropython.org\all` not working anymore.
 - fix device name instead of `None` in `put`, `get`, `fget`, `dsync` in `sslweb_repl` with `-nem` mode enabled.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2020-2021, Carlos G. Gonzalez'
 author = 'Carlos G. Gonzalez'
 
 # The full version, including alpha/beta/rc tags
-release = '0.3.6'
+release = '0.3.7'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/source/howto.rst
+++ b/docs/source/howto.rst
@@ -142,6 +142,13 @@ First enable port forwarding by editing ``/etc/sysctl.conf`` and uncomment
 
     net.ipv4.ip_forward=1
 
+And reload
+
+.. code-block:: console
+
+    $ sudo sysctl -p
+    net.ipv4.ip_forward = 1
+
 Then set the rules with ``iptables``
 
 .. code-block:: console

--- a/docs/source/modetools.rst
+++ b/docs/source/modetools.rst
@@ -376,7 +376,10 @@ Group Mode
 
     To send a command to multiple devices in a group (made with make_group command)
 
-    To target specific devices within a group add -devs option as -devs [DEV NAME] [DEV NAME] ...
+    To target specific devices within a group add ``-devs`` option as ``-devs [DEV NAME] [DEV NAME] ...``
+    or use ``-@ [DEV NAME] [DEV NAME] ...`` which has autocompletion on tab and accepts group names, \* wildcards or brace expansion.
+
+    e.g. ``$ upydev check -@ esp\*``, ``$ upydev check -@ esp{1..3}`` 
 
 .. note::
     *upydev will use local working directory  group configuration unless it does

--- a/docs/source/modetools.rst
+++ b/docs/source/modetools.rst
@@ -85,7 +85,7 @@ Device Management
           password of each board) or ``-rm`` to remove devices (indicated by name)
 
       - make_sgroup:
-          To make a subset group of an existant group, alias ``mksg``.  Use -f for the name
+          To make a subset group of an existing group, alias ``mksg``.  Use -f for the name
           of the subgroup, -G for the name of parent group and -devs option to indicate the names
           of the devices to include.
 

--- a/docs/source/modetools.rst
+++ b/docs/source/modetools.rst
@@ -62,7 +62,7 @@ Help
 Device Management
 -----------------
 
-    ACTIONS : ``config``, ``check``, ``set``, ``make_group``, ``mg_group``, ``see``, ``gg``
+    ACTIONS : ``config``, ``check``, ``set``, ``make_group``, ``mg_group``, ``make_sgroup``, ``see``, ``gg``
 
 
       - config:
@@ -83,6 +83,11 @@ Device Management
           To manage a group of devices to send commands to. Use ``-G`` for the name
           of the group and ``-add`` option to add devices (indicate a name, ip and the
           password of each board) or ``-rm`` to remove devices (indicated by name)
+
+      - make_sgroup:
+          To make a subset group of an existant group, alias ``mksg``.  Use -f for the name
+          of the subgroup, -G for the name of parent group and -devs option to indicate the names
+          of the devices to include.
 
       - see:
           To get specific info about a devices group use ``-G`` option as ``see -G [GROUP NAME]``

--- a/docs/source/upycmd.rst
+++ b/docs/source/upycmd.rst
@@ -34,6 +34,8 @@ General Commands
         - **set_localtime**: to pass host localtime and set upy device rtc
         - **set_ntptime**: to set rtc from server, (see ``-utc`` for time zone)
         - **get_datetime**: to get date and time (must be set first, see above commands)
+        - **set_hostname**: to set hostname of the device for dhcp service *(needs wpa_supplicant.py)*
+        - **set_localname**: to set localname of the device for ble gap/advertising name *(needs ble_uart_peripheral.py)*
 
 
 WiFi Utils

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -32,7 +32,7 @@ Mode/Tools
 	> :ref:`modetools:Device Management`
 			To manage configuration of a device/group of devices.
 
-			ACTIONS : ``config``, ``check``, ``set``, ``make_group``, ``mg_group``, ``see``, ``gg``
+			ACTIONS : ``config``, ``check``, ``set``, ``make_group``, ``mg_group``, ``make_sgroup``, ``see``, ``gg``
 
 	> :ref:`modetools:File IO operations`
 			To upload/download files to/from a device.

--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,5 @@ setup(name='upydev',
       install_requires=['websocket-client', 'argcomplete',
                         'esptool', 'prompt_toolkit', 'python-nmap',
                         'netifaces', 'requests', 'cryptography', 'Pygments',
-                        'pyusb', 'packaging', 'upydevice>=0.3.2',
+                        'pyusb', 'packaging', 'upydevice>=0.3.3',
                         'jupyter_micropython_upydevice>=0.0.5'])

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ def readme():
 
 
 setup(name='upydev',
-      version='0.3.6',
+      version='0.3.7',
       description='Command line tool for wired/wireless MicroPython devices',
       long_description=readme(),
       long_description_content_type='text/markdown',
@@ -52,5 +52,5 @@ setup(name='upydev',
       install_requires=['websocket-client', 'argcomplete',
                         'esptool', 'prompt_toolkit', 'python-nmap',
                         'netifaces', 'requests', 'cryptography', 'Pygments',
-                        'pyusb', 'packaging', 'upydevice>=0.3.1',
+                        'pyusb', 'packaging', 'upydevice>=0.3.2',
                         'jupyter_micropython_upydevice>=0.0.5'])

--- a/shr_srepl_cli/bin/sh_srepl
+++ b/shr_srepl_cli/bin/sh_srepl
@@ -771,7 +771,7 @@ custom_sh_cmd_kw = ['df', 'datetime', 'ifconfig', 'ifconfig_t', 'netscan',
                     'batl', 'fw', 'flash', 'du', 'ldu', 'dsync', 'upipl',
                     'uping', 'lping', 'pkg_info', 'update_upyutils',
                     'timeit', 'i2c', 'dump_mem', 'git', 'emacs', 'batstyle',
-                    'upy-config', 'tig', 'jupyterc', 'pytest']
+                    'upy-config', 'tig', 'jupyterc', 'pytest', 'rssi']
 CRED = '\033[91;1m'
 CGREEN = '\33[32;1m'
 CEND = '\033[0m'
@@ -1571,6 +1571,14 @@ def custom_sh_cmd(cmd_inp):
         else:
             print('STA interface not connected')
 
+    if cmd_inp == 'rssi':
+        sta_isconnected = send_custom_sh_cmd(
+            "import network;network.WLAN(network.STA_IF).isconnected()")
+        if sta_isconnected:
+            signal_rssi = send_custom_sh_cmd(
+                "network.WLAN(network.STA_IF).status('rssi')")
+            print(signal_rssi)
+
     if cmd_inp == 'netscan':
         enable_sta = send_custom_sh_cmd(
             "import network;network.WLAN(network.STA_IF).active(1)")
@@ -2108,9 +2116,9 @@ def custom_sh_cmd(cmd_inp):
             pass
 
     if cmd_inp.split(' ')[0] == 'vim':
-        print('<-- Vim editor -->')
-        print('Use I to insert; (ESC , :w) to write; (ESC ,:q) to exit')
-        time.sleep(1)
+        # print('<-- Vim editor -->')
+        # print('Use I to insert; (ESC , :w) to write; (ESC ,:q) to exit')
+        # time.sleep(1)
         try:
             file_to_edit = cmd_inp.split(' ')[1]
             lvim = 'vim {}'.format(file_to_edit)
@@ -2125,9 +2133,9 @@ def custom_sh_cmd(cmd_inp):
             pass
 
     if 'emacs' in cmd_inp.split(' ')[0]:
-        print('<-- Emacs editor -->')
-        print('Use Ctrl-x-Ctrl-s to Save,  Ctrl-x-Ctrl-c to exit')
-        time.sleep(1)
+        # print('<-- Emacs editor -->')
+        # print('Use Ctrl-x-Ctrl-s to Save,  Ctrl-x-Ctrl-c to exit')
+        # time.sleep(1)
         try:
             file_to_edit = cmd_inp.split(' ')[1]
             lemacs = 'emacs {} -nw'.format(file_to_edit)

--- a/ssl_web_repl_cli/bin/sslweb_repl
+++ b/ssl_web_repl_cli/bin/sslweb_repl
@@ -996,7 +996,7 @@ custom_sh_cmd_kw = ['df', 'datetime', 'ifconfig', 'ifconfig_t', 'netscan',
                     'getcert', 'get_rawbuff', 'l_tree', 'view', 'bat', 'rcat',
                     'batl', 'du', 'ldu', 'upipl', 'pkg_info', 'uping', 'lping',
                     'timeit', 'i2c', 'dump_mem', 'git', 'emacs', 'batstyle',
-                    'upy-config', 'wss', 'tig', 'jupyterc', 'pytest']
+                    'upy-config', 'wss', 'tig', 'jupyterc', 'pytest', 'rssi']
 CRED = '\033[91;1m'
 CGREEN = '\33[32;1m'
 CEND = '\033[0m'
@@ -1850,6 +1850,14 @@ def custom_sh_cmd(cmd_inp):
         else:
             print('STA interface not connected')
 
+    if cmd_inp == 'rssi':
+        sta_isconnected = send_custom_sh_cmd(
+            "import network;network.WLAN(network.STA_IF).isconnected()")
+        if sta_isconnected:
+            signal_rssi = send_custom_sh_cmd(
+                "network.WLAN(network.STA_IF).status('rssi')")
+            print(signal_rssi)
+
     if cmd_inp == 'netscan':
         if espdev.dev_platform == 'esp8266':
             enable_sta = send_custom_sh_cmd(
@@ -2158,18 +2166,18 @@ def custom_sh_cmd(cmd_inp):
             try:
                 file = cmd_inp.split(' ')[1]  #  HERE CALL ONE OR -FRE
                 if file == 'cwd':
-                    get_str = 'upydev get -fre {} -t {} -p {} {}'.format(
-                        file, args.t, args.p, dev_dir)
+                    get_str = 'upydev get -fre {} -t {} -p {} {} -@ {}'.format(file,
+                        args.t, args.p, dev_dir, args.dev)
                 elif '*' in file:
-                    get_str = 'upydev get -fre {} -t {} -p {} {}'.format(
-                        file.replace('*', ''), args.t, args.p, dev_dir)
+                    get_str = 'upydev get -fre {} -t {} -p {} {} -@ {}'.format(
+                        file.replace('*', ''), args.t, args.p, dev_dir, args.dev)
                 elif len(cmd_inp.split(' ')) > 2:
                     file = ' '.join(cmd_inp.split(' ')[1:])
-                    get_str = 'upydev get -fre {} -t {} -p {} {}'.format(
-                        file, args.t, args.p, dev_dir)
+                    get_str = 'upydev get -fre {} -t {} -p {} {} -@ {}'.format(
+                        file, args.t, args.p, dev_dir, args.dev)
                 else:
-                    get_str = 'upydev get -f {} -t {} -p {} {}'.format(
-                        file, args.t, args.p, dev_dir)
+                    get_str = 'upydev get -f {} -t {} -p {} {} -@ {}'.format(
+                        file, args.t, args.p, dev_dir, args.dev)
                 get_cmd = shlex.split(get_str)
                 try:
                     get_file = subprocess.call(get_cmd)
@@ -2269,18 +2277,18 @@ def custom_sh_cmd(cmd_inp):
         try:
             file = cmd_inp.split(' ')[1]  #  HERE CALL ONE OR -FRE
             if file == 'cwd':
-                get_str = 'upydev fget -fre {} -t {} -p {} {}'.format(
-                    file, args.t, args.p, dev_dir)
+                get_str = 'upydev fget -fre {} -t {} -p {} {} -@ {}'.format(
+                    file, args.t, args.p, dev_dir, args.dev)
             elif '*' in file:
-                get_str = 'upydev fget -fre {} -t {} -p {} {}'.format(
-                    file.replace('*', ''), args.t, args.p, dev_dir)
+                get_str = 'upydev fget -fre {} -t {} -p {} {} -@ {}'.format(
+                    file.replace('*', ''), args.t, args.p, dev_dir, args.dev)
             elif len(cmd_inp.split(' ')) > 2:
                 file = ' '.join(cmd_inp.split(' ')[1:])
-                get_str = 'upydev fget -fre {} -t {} -p {} {}'.format(
-                    file, args.t, args.p, dev_dir)
+                get_str = 'upydev fget -fre {} -t {} -p {} {} -@ {}'.format(
+                    file, args.t, args.p, dev_dir, args.dev)
             else:
-                get_str = 'upydev fget -f {} -t {} -p {} {}'.format(
-                    file, args.t, args.p, dev_dir)
+                get_str = 'upydev fget -f {} -t {} -p {} {} -@ {}'.format(
+                    file, args.t, args.p, dev_dir, args.dev)
 
             sync_cmd = shlex.split(get_str)
             try:
@@ -2317,18 +2325,18 @@ def custom_sh_cmd(cmd_inp):
 
                 file = cmd_inp.split(' ')[1]  #  HERE CALL ONE OR -FRE
                 if file == 'cwd':
-                    put_str = 'upydev put -fre {} -t {} -p {} {} -rst f'.format(
-                        file, args.t, args.p, dev_dir)
+                    put_str = 'upydev put -fre {} -t {} -p {} {} -rst f -@ {}'.format(
+                        file, args.t, args.p, dev_dir, args.dev)
                 elif '*' in file:
-                    put_str = 'upydev put -fre {} -t {} -p {} {} -rst f'.format(
-                        file.replace('*', ''), args.t, args.p, dev_dir)
+                    put_str = 'upydev put -fre {} -t {} -p {} {} -rst f -@ {}'.format(
+                        file.replace('*', ''), args.t, args.p, dev_dir, args.dev)
                 elif len(cmd_inp.split(' ')) > 2:
                     file = ' '.join(cmd_inp.split(' ')[1:])
-                    put_str = 'upydev put -fre {} -t {} -p {} {} -rst f'.format(
-                        file, args.t, args.p, dev_dir)
+                    put_str = 'upydev put -fre {} -t {} -p {} {} -rst f -@ {}'.format(
+                        file, args.t, args.p, dev_dir, args.dev)
                 else:
-                    put_str = 'upydev put -f {} -t {} -p {} {} -rst f'.format(
-                        file, args.t, args.p, dev_dir)
+                    put_str = 'upydev put -f {} -t {} -p {} {} -rst f -@ {}'.format(
+                        file, args.t, args.p, dev_dir, args.dev)
                 put_cmd = shlex.split(put_str)
                 try:
                     put_file = subprocess.call(put_cmd)
@@ -2430,8 +2438,8 @@ def custom_sh_cmd(cmd_inp):
             if cmd_inp.split()[-1] == '.':
                 file = ' '.join([fl for fl in os.listdir()
                                  if os.path.isfile(fl) and not fl.startswith('.')])
-                put_str = 'upydev put -fre {} -t {} -p {} {} -rst f'.format(
-                    file, args.t, args.p, '')
+                put_str = 'upydev put -fre {} -t {} -p {} {} -rst f -@ {}'.format(
+                    file, args.t, args.p, '', args.dev)
                 put_cmd = shlex.split(put_str)
                 try:
                     put_file = subprocess.call(put_cmd)
@@ -2458,9 +2466,10 @@ def custom_sh_cmd(cmd_inp):
                 for _dir in dirs_to_sync:
                     print('- {}'.format(_dir))
 
-                    d_sync_str = 'upydev dsync -t {} -p {} -dir {} -rst f'.format(args.t,
+                    d_sync_str = 'upydev dsync -t {} -p {} -dir {} -rst f -@ {}'.format(args.t,
                                                                                   args.p,
-                                                                                  _dir)
+                                                                                  _dir,
+                                                                                  args.dev)
 
                     d_sync_cmd = shlex.split(d_sync_str)
                     try:
@@ -2485,9 +2494,10 @@ def custom_sh_cmd(cmd_inp):
                 try:
                     dir_to_sync = cmd_inp.split(' ')[1]  #  HERE CALL ONE OR -FRE
 
-                    d_sync_str = 'upydev dsync -t {} -p {} -dir {} -rst f'.format(args.t,
+                    d_sync_str = 'upydev dsync -t {} -p {} -dir {} -rst f -@ {}'.format(args.t,
                                                                                   args.p,
-                                                                                  dir_to_sync)
+                                                                                  dir_to_sync,
+                                                                                  args.dev)
 
                     d_sync_cmd = shlex.split(d_sync_str)
                     try:
@@ -2640,9 +2650,9 @@ def custom_sh_cmd(cmd_inp):
             pass
 
     if cmd_inp.split(' ')[0] == 'vim':
-        print('<-- Vim editor -->')
-        print('Use I to insert; (ESC , :w) to write; (ESC ,:q) to exit')
-        time.sleep(1)
+        # print('<-- Vim editor -->')
+        # print('Use I to insert; (ESC , :w) to write; (ESC ,:q) to exit')
+        # time.sleep(1)
         try:
             file_to_edit = cmd_inp.split(' ')[1]
             lvim = 'vim {}'.format(file_to_edit)
@@ -2657,9 +2667,9 @@ def custom_sh_cmd(cmd_inp):
             pass
 
     if 'emacs' in cmd_inp.split(' ')[0]:
-        print('<-- Emacs editor -->')
-        print('Use Ctrl-x-Ctrl-s to Save,  Ctrl-x-Ctrl-c to exit')
-        time.sleep(1)
+        # print('<-- Emacs editor -->')
+        # print('Use Ctrl-x-Ctrl-s to Save,  Ctrl-x-Ctrl-c to exit')
+        # time.sleep(1)
         try:
             file_to_edit = cmd_inp.split(' ')[1]
             lemacs = 'emacs {} -nw'.format(file_to_edit)

--- a/ssl_web_repl_cli/bin/sslweb_repl
+++ b/ssl_web_repl_cli/bin/sslweb_repl
@@ -1383,39 +1383,39 @@ class DISK_USAGE:
 
     def __call__(self, path=".", dlev=0, max_dlev=0, hidden=False, absp=True):
         if path != ".":
-               if not os.stat(path)[0] & 0x4000:
-                    print('{:9} {}'.format(
+            if not os.stat(path)[0] & 0x4000:
+                print('{:9} {}'.format(
                         self.print_filesys_info(os.stat(path)[6]), path))
+            else:
+                if hidden:
+                    resp = {
+                        path+'/'+dir: os.stat(path+'/'+dir)[6] for dir in os.listdir(path)}
                 else:
-                    if hidden:
-                        resp = {
-                            path+'/'+dir: os.stat(path+'/'+dir)[6] for dir in os.listdir(path)}
-                    else:
-                        resp = {
-                            path+'/'+dir: os.stat(path+'/'+dir)[6] for dir in os.listdir(path) if not dir.startswith('.')}
-                    for dir in resp.keys():
+                    resp = {
+                        path+'/'+dir: os.stat(path+'/'+dir)[6] for dir in os.listdir(path) if not dir.startswith('.')}
+                for dir in resp.keys():
 
-                        if not os.stat(dir)[0] & 0x4000:
-                            if absp:
-                                print('{:9} {}'.format(
-                                    self.print_filesys_info(resp[dir]), dir))
-                            else:
-                                print('{:9} {}'.format(self.print_filesys_info(
-                                    resp[dir]), dir.split('/')[-1]))
-
+                    if not os.stat(dir)[0] & 0x4000:
+                        if absp:
+                            print('{:9} {}'.format(
+                                self.print_filesys_info(resp[dir]), dir))
                         else:
-                            if dlev < max_dlev:
-                                dlev += 1
-                                self.__call__(path=dir, dlev=dlev,
-                                              max_dlev=max_dlev, hidden=hidden)
-                                dlev += (-1)
+                            print('{:9} {}'.format(self.print_filesys_info(
+                                resp[dir]), dir.split('/')[-1]))
+
+                    else:
+                        if dlev < max_dlev:
+                            dlev += 1
+                            self.__call__(path=dir, dlev=dlev,
+                                          max_dlev=max_dlev, hidden=hidden)
+                            dlev += (-1)
+                        else:
+                            if absp:
+                                print('{:9} \u001b[34;1m{}\033[0m'.format(
+                                    self.print_filesys_info(self.get_dir_size_recursive(dir)), dir))
                             else:
-                                if absp:
-                                    print('{:9} \u001b[34;1m{}\033[0m'.format(
-                                        self.print_filesys_info(self.get_dir_size_recursive(dir)), dir))
-                                else:
-                                    print('{:9} \u001b[34;1m{}\033[0m'.format(self.print_filesys_info(
-                                        self.get_dir_size_recursive(dir)), dir.split('/')[-1]))
+                                print('{:9} \u001b[34;1m{}\033[0m'.format(self.print_filesys_info(
+                                    self.get_dir_size_recursive(dir)), dir.split('/')[-1]))
 
         else:
             if hidden:
@@ -4237,78 +4237,78 @@ def paste_mode_exit(event):
     # event.app.current_buffer.insert_text('import')
 
     def cmd_paste_exit(buff_P=paste_buffer['B']):
-           buff_text = '\n'.join(
+        buff_text = '\n'.join(
                 buff_P + [event.app.current_buffer.document.text])
-            if buff_text is not None and buff_text != '':
+        if buff_text is not None and buff_text != '':
+            # espdev.wr_cmd("cp.gbls = globals()", silent=True)
+            if not encrypted_flag['sec']:
+                # block_commad = uparser_dec('\n' + buff_text, end='\r\r\r')
+                # espdev.wr_cmd(block_commad)
+                # print(block_commad.splitlines())
+                try:
+                    espdev.paste_buff(buff_text)
+                    espdev.wr_cmd("\x04", follow=True)
+                except KeyboardInterrupt:
+                    time.sleep(0.2)
+                    espdev.wr_cmd('\x03')  # KBI
+                    time.sleep(0.2)
+                    for i in range(1):
+                        espdev.wr_cmd('\x0d', silent=True)
+
+            else:
                 # espdev.wr_cmd("cp.gbls = globals()", silent=True)
-                if not encrypted_flag['sec']:
-                    # block_commad = uparser_dec('\n' + buff_text, end='\r\r\r')
-                    # espdev.wr_cmd(block_commad)
-                    # print(block_commad.splitlines())
-                    try:
-                        espdev.paste_buff(buff_text)
-                        espdev.wr_cmd("\x04", follow=True)
-                    except KeyboardInterrupt:
-                        time.sleep(0.2)
-                        espdev.wr_cmd('\x03')  # KBI
-                        time.sleep(0.2)
-                        for i in range(1):
-                            espdev.wr_cmd('\x0d', silent=True)
-
-                else:
-                    # espdev.wr_cmd("cp.gbls = globals()", silent=True)
-                    try:
-                        ssl_cp.paste_buff(buff_text)
-                        ssl_cp.ssl_repl("\x04", follow=True)
-                    except KeyboardInterrupt:
-                        time.sleep(0.2)
-                        ssl_cp.ssl_repl('\x03', silent=True,
-                                        traceback=True)  # KBI
-                        time.sleep(0.2)
-                        for i in range(1):
-                            ssl_cp.ssl_repl('\x0d', silent=True)
-                            ssl_cp.flush_conn()
-                        pass
-                    # ssl_cp.ssl_repl('', just_recv=True, silent=False) blocking
-                    # if espdev.output is not None:
-                    #     print(espdev.output)
-                    espdev.output = None
-                    time.sleep(1)
-                    if encrypted_flag['sec']:
+                try:
+                    ssl_cp.paste_buff(buff_text)
+                    ssl_cp.ssl_repl("\x04", follow=True)
+                except KeyboardInterrupt:
+                    time.sleep(0.2)
+                    ssl_cp.ssl_repl('\x03', silent=True,
+                                    traceback=True)  # KBI
+                    time.sleep(0.2)
+                    for i in range(1):
+                        ssl_cp.ssl_repl('\x0d', silent=True)
                         ssl_cp.flush_conn()
-                        ssl_cp.flush_conn()
-            # print('paste mode; Ctrl-C to cancel, Ctrl-D to finish')
-            event.app.current_buffer.reset()
-            # print(buff_text)
-            print(">>> ")
-            prompt['p'] = ">>> "
-
-    def cmd_edit_exit(file_to_edit=edit_mode['File']):
-           buff_text = ''.join([event.app.current_buffer.document.text])
-            if buff_text is not None and buff_text != '':
-                send_custom_sh_cmd(
-                    "_file_to_edit = open('{}','w')".format(file_to_edit))
-                send_custom_sh_cmd("nl = '\\n'")
-                print('Writing to file...')
-                lines_to_write = buff_text.split('\n')
-                for line in lines_to_write:
-                    if line != ' ' and line != "" and line != '':
-                        send_custom_sh_cmd(
-                            '_file_to_edit.write("{}")'.format(line))
-                        # if not encrypted_flag['sec']:
-                        send_custom_sh_cmd('_file_to_edit.write(nl)')
-                    # time.sleep(0.1)
-                send_custom_sh_cmd("_file_to_edit.close()")
-                send_custom_sh_cmd("gc.collect()")
-                time.sleep(0.5)
+                    pass
+                # ssl_cp.ssl_repl('', just_recv=True, silent=False) blocking
+                # if espdev.output is not None:
+                #     print(espdev.output)
+                espdev.output = None
+                time.sleep(1)
                 if encrypted_flag['sec']:
                     ssl_cp.flush_conn()
                     ssl_cp.flush_conn()
-            # print('paste mode; Ctrl-C to cancel, Ctrl-D to finish')
-            event.app.current_buffer.reset()
-            # print(buff_text)
-            print("File {} edited successfully!".format(file_to_edit))
-            print('PRESS ESC, THEN ENTER TO EXIT EDIT MODE')
+        # print('paste mode; Ctrl-C to cancel, Ctrl-D to finish')
+        event.app.current_buffer.reset()
+        # print(buff_text)
+        print(">>> ")
+        prompt['p'] = ">>> "
+
+    def cmd_edit_exit(file_to_edit=edit_mode['File']):
+        buff_text = ''.join([event.app.current_buffer.document.text])
+        if buff_text is not None and buff_text != '':
+            send_custom_sh_cmd(
+                "_file_to_edit = open('{}','w')".format(file_to_edit))
+            send_custom_sh_cmd("nl = '\\n'")
+            print('Writing to file...')
+            lines_to_write = buff_text.split('\n')
+            for line in lines_to_write:
+                if line != ' ' and line != "" and line != '':
+                    send_custom_sh_cmd(
+                        '_file_to_edit.write("{}")'.format(line))
+                    # if not encrypted_flag['sec']:
+                    send_custom_sh_cmd('_file_to_edit.write(nl)')
+                # time.sleep(0.1)
+            send_custom_sh_cmd("_file_to_edit.close()")
+            send_custom_sh_cmd("gc.collect()")
+            time.sleep(0.5)
+            if encrypted_flag['sec']:
+                ssl_cp.flush_conn()
+                ssl_cp.flush_conn()
+        # print('paste mode; Ctrl-C to cancel, Ctrl-D to finish')
+        event.app.current_buffer.reset()
+        # print(buff_text)
+        print("File {} edited successfully!".format(file_to_edit))
+        print('PRESS ESC, THEN ENTER TO EXIT EDIT MODE')
     if not shell_mode['S']:
         if paste_flag['p']:
             # print(paste_buffer['B'])
@@ -4632,86 +4632,50 @@ def autocomplete_locals(event):
 
         def s_r_cmd_info(rest_part=rest, flag=glb, buff=buff_text, output=cmd_ls_glb):
             try:
-                   if isinstance(cmd_ls_glb, str):
-                        # print(espdev.output)
-                        pass
-                    else:
-                        if rest != '':
-                            result = [
-                                val for val in output if val.startswith(rest)]
-                            if len(result) > 1:
-                                comm_part = os.path.commonprefix(result)
-                                if comm_part == rest:
-                                    if shell_mode['S']:
-                                        last_cmd = event.app.current_buffer.document.text
-                                        if local_path['p'] == '':
-                                            g_p = [val[1]
-                                                   for val in prompt['p'][1:5]]
-                                            b_p = [val[1]
-                                                   for val in prompt['p'][5:]]
-                                            color_p = "\33[32;1m{}\033[0m:\u001b[34;1m{}\033[0m{}".format(
-                                                "".join(g_p[:-1]), "".join(b_p), last_cmd)
-                                            print(color_p)
-                                        else:
-                                            m_p = [prompt['p'][0][1]]
-                                            g_p = [val[1]
-                                                   for val in prompt['p'][1:5]]
-                                            b_p = [val[1]
-                                                   for val in prompt['p'][5:]]
-                                            color_p = "\u001b[35;1m{}\033[0m\33[32;1m{}\033[0m:\u001b[34;1m{}\033[0m{}".format(
-                                                "".join(m_p), "".join(g_p[:-1]), "".join(b_p), last_cmd)
-                                            print(color_p)
-                                    print_table(result, wide=28, format_SH=True)
-                                else:
-                                    event.app.current_buffer.insert_text(
-                                        comm_part[len(rest):])
+                if isinstance(cmd_ls_glb, str):
+                    # print(espdev.output)
+                    pass
+                else:
+                    if rest != '':
+                        result = [
+                            val for val in output if val.startswith(rest)]
+                        if len(result) > 1:
+                            comm_part = os.path.commonprefix(result)
+                            if comm_part == rest:
+                                if shell_mode['S']:
+                                    last_cmd = event.app.current_buffer.document.text
+                                    if local_path['p'] == '':
+                                        g_p = [val[1]
+                                               for val in prompt['p'][1:5]]
+                                        b_p = [val[1]
+                                               for val in prompt['p'][5:]]
+                                        color_p = "\33[32;1m{}\033[0m:\u001b[34;1m{}\033[0m{}".format(
+                                            "".join(g_p[:-1]), "".join(b_p), last_cmd)
+                                        print(color_p)
+                                    else:
+                                        m_p = [prompt['p'][0][1]]
+                                        g_p = [val[1]
+                                               for val in prompt['p'][1:5]]
+                                        b_p = [val[1]
+                                               for val in prompt['p'][5:]]
+                                        color_p = "\u001b[35;1m{}\033[0m\33[32;1m{}\033[0m:\u001b[34;1m{}\033[0m{}".format(
+                                            "".join(m_p), "".join(g_p[:-1]), "".join(b_p), last_cmd)
+                                        print(color_p)
+                                print_table(result, wide=28, format_SH=True)
                             else:
                                 event.app.current_buffer.insert_text(
-                                    result[0][len(rest):])
+                                    comm_part[len(rest):])
                         else:
-                            if not glb:
-                                if shell_mode['S']:
-                                    result = [val for val in output if val.startswith(
-                                        buff_text.split('/')[-1])]
-                                    if len(result) > 1:
-                                        comm_part = os.path.commonprefix(result)
-                                        if comm_part == buff_text.split('/')[-1]:
-                                            if shell_mode['S']:
-                                                last_cmd = event.app.current_buffer.document.text
-                                                if local_path['p'] == '':
-                                                    g_p = [val[1]
-                                                           for val in prompt['p'][1:5]]
-                                                    b_p = [val[1]
-                                                           for val in prompt['p'][5:]]
-                                                    color_p = "\33[32;1m{}\033[0m:\u001b[34;1m{}\033[0m{}".format(
-                                                        "".join(g_p[:-1]), "".join(b_p), last_cmd)
-                                                    print(color_p)
-                                                else:
-                                                    m_p = [prompt['p'][0][1]]
-                                                    g_p = [val[1]
-                                                           for val in prompt['p'][1:5]]
-                                                    b_p = [val[1]
-                                                           for val in prompt['p'][5:]]
-                                                    color_p = "\u001b[35;1m{}\033[0m\33[32;1m{}\033[0m:\u001b[34;1m{}\033[0m{}".format(
-                                                        "".join(m_p), "".join(g_p[:-1]), "".join(b_p), last_cmd)
-                                                    print(color_p)
-                                                # format ouput
-                                                print_table(
-                                                    result, wide=28, format_SH=True)
-                                        else:
-                                            event.app.current_buffer.insert_text(
-                                                comm_part[len(buff_text.split('/')[-1]):])
-                                    else:
-                                        event.app.current_buffer.insert_text(
-                                            result[0][len(buff_text.split('/')[-1]):])
-                                else:
-                                    print_table(output, wide=28, format_SH=True)
-                            else:
-                                result = [
-                                    val for val in output if val.startswith(buff_text)]
+                            event.app.current_buffer.insert_text(
+                                result[0][len(rest):])
+                    else:
+                        if not glb:
+                            if shell_mode['S']:
+                                result = [val for val in output if val.startswith(
+                                    buff_text.split('/')[-1])]
                                 if len(result) > 1:
                                     comm_part = os.path.commonprefix(result)
-                                    if comm_part == buff_text:
+                                    if comm_part == buff_text.split('/')[-1]:
                                         if shell_mode['S']:
                                             last_cmd = event.app.current_buffer.document.text
                                             if local_path['p'] == '':
@@ -4731,20 +4695,56 @@ def autocomplete_locals(event):
                                                 color_p = "\u001b[35;1m{}\033[0m\33[32;1m{}\033[0m:\u001b[34;1m{}\033[0m{}".format(
                                                     "".join(m_p), "".join(g_p[:-1]), "".join(b_p), last_cmd)
                                                 print(color_p)
-
                                             # format ouput
-                                            print_table(
-                                                result, wide=28, format_SH=True)
-                                        else:
-                                            print('>>> {}'.format(buff_text))
                                             print_table(
                                                 result, wide=28, format_SH=True)
                                     else:
                                         event.app.current_buffer.insert_text(
-                                            comm_part[len(buff_text):])
+                                            comm_part[len(buff_text.split('/')[-1]):])
                                 else:
                                     event.app.current_buffer.insert_text(
-                                        result[0][len(buff_text):])
+                                        result[0][len(buff_text.split('/')[-1]):])
+                            else:
+                                print_table(output, wide=28, format_SH=True)
+                        else:
+                            result = [
+                                val for val in output if val.startswith(buff_text)]
+                            if len(result) > 1:
+                                comm_part = os.path.commonprefix(result)
+                                if comm_part == buff_text:
+                                    if shell_mode['S']:
+                                        last_cmd = event.app.current_buffer.document.text
+                                        if local_path['p'] == '':
+                                            g_p = [val[1]
+                                                   for val in prompt['p'][1:5]]
+                                            b_p = [val[1]
+                                                   for val in prompt['p'][5:]]
+                                            color_p = "\33[32;1m{}\033[0m:\u001b[34;1m{}\033[0m{}".format(
+                                                "".join(g_p[:-1]), "".join(b_p), last_cmd)
+                                            print(color_p)
+                                        else:
+                                            m_p = [prompt['p'][0][1]]
+                                            g_p = [val[1]
+                                                   for val in prompt['p'][1:5]]
+                                            b_p = [val[1]
+                                                   for val in prompt['p'][5:]]
+                                            color_p = "\u001b[35;1m{}\033[0m\33[32;1m{}\033[0m:\u001b[34;1m{}\033[0m{}".format(
+                                                "".join(m_p), "".join(g_p[:-1]), "".join(b_p), last_cmd)
+                                            print(color_p)
+
+                                        # format ouput
+                                        print_table(
+                                            result, wide=28, format_SH=True)
+                                    else:
+                                        print('>>> {}'.format(buff_text))
+                                        print_table(
+                                            result, wide=28, format_SH=True)
+                                else:
+                                    event.app.current_buffer.insert_text(
+                                        comm_part[len(buff_text):])
+                            else:
+                                event.app.current_buffer.insert_text(
+                                    result[0][len(buff_text):])
 
             except Exception as e:
                 pass

--- a/ssl_web_repl_cli/bin/sslweb_repl
+++ b/ssl_web_repl_cli/bin/sslweb_repl
@@ -1198,8 +1198,8 @@ def print_table(data, cols=4, wide=16, format_SH=False, autocols=True,
         data = ['{}{}{}{}'.format(
             CGREEN, val, CEND, ' '*(wide-len(val))) if '.mpy' in val else val for val in data]
     if autocol_tab:
-        data = [namefile if len(namefile) < wide else namefile +
-                '\n' for namefile in data]
+        data = [namefile if len(namefile) < wide else namefile
+                + '\n' for namefile in data]
     if autowide:
         wide_data = max([len(namefile) for namefile in data]) + 2
         if wide_data > wide:
@@ -1258,12 +1258,12 @@ def map_upysh(cmd_inp):
 
 
 def _dt_format(number):
-        rtc_n = str(number)
-        if len(rtc_n) == 1:
-            rtc_n = "0{}".format(rtc_n)
-            return rtc_n
-        else:
-            return rtc_n
+    rtc_n = str(number)
+    if len(rtc_n) == 1:
+        rtc_n = "0{}".format(rtc_n)
+        return rtc_n
+    else:
+        return rtc_n
 
 
 def _ft_datetime(t_now):
@@ -1383,7 +1383,7 @@ class DISK_USAGE:
 
     def __call__(self, path=".", dlev=0, max_dlev=0, hidden=False, absp=True):
         if path != ".":
-                if not os.stat(path)[0] & 0x4000:
+               if not os.stat(path)[0] & 0x4000:
                     print('{:9} {}'.format(
                         self.print_filesys_info(os.stat(path)[6]), path))
                 else:
@@ -2167,7 +2167,7 @@ def custom_sh_cmd(cmd_inp):
                 file = cmd_inp.split(' ')[1]  #  HERE CALL ONE OR -FRE
                 if file == 'cwd':
                     get_str = 'upydev get -fre {} -t {} -p {} {} -@ {}'.format(file,
-                        args.t, args.p, dev_dir, args.dev)
+                                                                               args.t, args.p, dev_dir, args.dev)
                 elif '*' in file:
                     get_str = 'upydev get -fre {} -t {} -p {} {} -@ {}'.format(
                         file.replace('*', ''), args.t, args.p, dev_dir, args.dev)
@@ -2467,9 +2467,9 @@ def custom_sh_cmd(cmd_inp):
                     print('- {}'.format(_dir))
 
                     d_sync_str = 'upydev dsync -t {} -p {} -dir {} -rst f -@ {}'.format(args.t,
-                                                                                  args.p,
-                                                                                  _dir,
-                                                                                  args.dev)
+                                                                                        args.p,
+                                                                                        _dir,
+                                                                                        args.dev)
 
                     d_sync_cmd = shlex.split(d_sync_str)
                     try:
@@ -2495,9 +2495,9 @@ def custom_sh_cmd(cmd_inp):
                     dir_to_sync = cmd_inp.split(' ')[1]  #  HERE CALL ONE OR -FRE
 
                     d_sync_str = 'upydev dsync -t {} -p {} -dir {} -rst f -@ {}'.format(args.t,
-                                                                                  args.p,
-                                                                                  dir_to_sync,
-                                                                                  args.dev)
+                                                                                        args.p,
+                                                                                        dir_to_sync,
+                                                                                        args.dev)
 
                     d_sync_cmd = shlex.split(d_sync_str)
                     try:
@@ -4237,7 +4237,7 @@ def paste_mode_exit(event):
     # event.app.current_buffer.insert_text('import')
 
     def cmd_paste_exit(buff_P=paste_buffer['B']):
-            buff_text = '\n'.join(
+           buff_text = '\n'.join(
                 buff_P + [event.app.current_buffer.document.text])
             if buff_text is not None and buff_text != '':
                 # espdev.wr_cmd("cp.gbls = globals()", silent=True)
@@ -4284,7 +4284,7 @@ def paste_mode_exit(event):
             prompt['p'] = ">>> "
 
     def cmd_edit_exit(file_to_edit=edit_mode['File']):
-            buff_text = ''.join([event.app.current_buffer.document.text])
+           buff_text = ''.join([event.app.current_buffer.document.text])
             if buff_text is not None and buff_text != '':
                 send_custom_sh_cmd(
                     "_file_to_edit = open('{}','w')".format(file_to_edit))
@@ -4563,8 +4563,8 @@ def shif_tab(event):
     def autocomplete_sh_cmd():
         if shell_mode['S']:
             buff_text = event.app.current_buffer.document.text
-            result = [sh_cmd for sh_cmd in shell_commands +
-                      custom_sh_cmd_kw if sh_cmd.startswith(buff_text)]
+            result = [sh_cmd for sh_cmd in shell_commands
+                      + custom_sh_cmd_kw if sh_cmd.startswith(buff_text)]
             if len(result) > 1:
                 comm_part = os.path.commonprefix(result)
                 if comm_part == buff_text:
@@ -4613,7 +4613,7 @@ def autocomplete_locals(event):
                     rest = ''
                     glb = True
                     if shell_mode['S']:
-                            cmd_ls_glb = os.listdir()
+                           cmd_ls_glb = os.listdir()
                     # if encrypted_flag['sec']:
                     #     h_cp.crepl(cmd_ls_glb)
                     # else:
@@ -4632,7 +4632,7 @@ def autocomplete_locals(event):
 
         def s_r_cmd_info(rest_part=rest, flag=glb, buff=buff_text, output=cmd_ls_glb):
             try:
-                    if isinstance(cmd_ls_glb, str):
+                   if isinstance(cmd_ls_glb, str):
                         # print(espdev.output)
                         pass
                     else:
@@ -5015,8 +5015,8 @@ while repl:
             print(e)
             continue
     except EOFError:
-            # print('This is EOF ERROR!')
-            continue
+           # print('This is EOF ERROR!')
+           continue
         # espdev.reset()
         # sys.exit()
 

--- a/upydev/__init__.py
+++ b/upydev/__init__.py
@@ -5,5 +5,5 @@
 # @Last modified time: 2019-07-12T02:50:43+01:00
 name = 'upydev'
 # include upydev/upydev_.config
-version = '0.3.6'
+version = '0.3.7'
 from .websocket_helper import *

--- a/upydev/commandlib.py
+++ b/upydev/commandlib.py
@@ -106,6 +106,10 @@ SD_AUTO = "import SD_AM;gc.collect()"
 
 CHECK_UPYSH2 = "import os;'upysh2.py' in os.listdir('lib');gc.collect()"
 
+SET_HOSTNAME = "f=open('hostname.py','wb');f.write(b'{}');f.close();"
+
+SET_LOCALNAME = "f=open('localname.py','wb');f.write(b'{}');f.close();"
+
 CMDDICT_ = {'UID': UID, 'UPYSH': UPYSH, 'HELP': HELP, 'MOD': MODULES,
             'MEM': MEM, 'OS_STAT': OS_STAT, 'FILE_STAT': FILE_STAT,
             'CHECK_DIR': CHECK_DIR, 'STAT_FS': STAT_FS,
@@ -121,6 +125,7 @@ CMDDICT_ = {'UID': UID, 'UPYSH': UPYSH, 'HELP': HELP, 'MOD': MODULES,
             'WLAN_CONFIG': WLAN_CONFIG, 'WLAN_AP_CONFIG': WLAN_AP_CONFIG,
             'WLAN_CONN': WLAN_CONN, 'WLAN_AP_CONN': WLAN_AP_CONN,
             'SD_ENABLE': SD_ENABLE, 'SD_INIT': SD_INIT,
-            'SD_DEINIT': SD_DEINIT, 'SD_AUTO': SD_AUTO, 'CHECK_UPYSH2': CHECK_UPYSH2}
+            'SD_DEINIT': SD_DEINIT, 'SD_AUTO': SD_AUTO, 'CHECK_UPYSH2': CHECK_UPYSH2,
+            'SET_HOSTNAME': SET_HOSTNAME, 'SET_LOCALNAME': SET_LOCALNAME}
 
 _CMDDICT_ = {k: 'import gc;' + v for k, v in CMDDICT_.items()}

--- a/upydev/conftest.py
+++ b/upydev/conftest.py
@@ -6,6 +6,8 @@ def pytest_addoption(parser):
                      help="indicate the device with which to run the test")
     parser.addoption("--wss", action="store_true", default=False,
                      help="to indicate use of ssl if WebSecureREPL enabled in WebSocketDevice")
+    parser.addoption("--devp", action="store", default="default",
+                     help="indicate the device with which to run the test")
 
 
 @pytest.fixture

--- a/upydev/debugging.py
+++ b/upydev/debugging.py
@@ -99,12 +99,12 @@ def sortSecond(val):
 
 
 def _dt_format(number):
-        rtc_n = str(number)
-        if len(rtc_n) == 1:
-            rtc_n = "0{}".format(rtc_n)
-            return rtc_n
-        else:
-            return rtc_n
+    rtc_n = str(number)
+    if len(rtc_n) == 1:
+        rtc_n = "0{}".format(rtc_n)
+        return rtc_n
+    else:
+        return rtc_n
 
 
 def _ft_datetime(t_now):
@@ -1222,11 +1222,14 @@ def probe_device(addr, passwd):
         else:
             return False
     elif dt == 'WebSocketDevice':
-        dev = Device(addr, passwd)
-        status = dev.is_reachable()
-        if status:
-            return True
-        else:
+        try:
+            dev = Device(addr, passwd)
+            status = dev.is_reachable()
+            if status:
+                return True
+            else:
+                return False
+        except Exception:
             return False
 
     elif dt == 'BleDevice':

--- a/upydev/devicemanagement.py
+++ b/upydev/devicemanagement.py
@@ -132,8 +132,8 @@ def devicemanagement_action(args, **kargs):
                         args.p = 'pass'
         upydev_addr = args.t
         upydev_mdata = args.p
-        if vars(args)['@'] is not None:
-            upydev_name = vars(args)['@']
+        if vars(args)['@']:
+            upydev_name = vars(args)['@'][0]
         else:
             upydev_name = 'upydevice'
         upy_conf = {'addr': upydev_addr, 'passwd': upydev_mdata, 'name': upydev_name}
@@ -199,8 +199,8 @@ def devicemanagement_action(args, **kargs):
                 if "@" in args.b:
                     gf, entryp = args.b.split('@')
                     args.t, args.p = address_entry_point(entryp, gf, args=args)
-            if vars(args)['@'] is not None:
-                entryp = vars(args)['@']
+            if vars(args)['@']:
+                entryp = vars(args)['@'][0]
                 args.t, args.p = address_entry_point(entryp, args=args)
             if args.apmd:
                 args.t = '192.168.4.1'
@@ -215,32 +215,48 @@ def devicemanagement_action(args, **kargs):
     # CHECK
 
     if args.m == 'check':
-        if vars(args)['@'] is not None:
-            print('Device: {}'.format(entryp))
+        if vars(args)['@']:
+            space = ''
+            for dev in vars(args)['@']:
+                try:
+                    args.t, args.p = address_entry_point(dev, args=args)
+                    print('{}Device: {}'.format(space, dev))
+                    dt = check_device_type(args.t)
+                    if not args.i:
+                        print('Address: {}, Device Type: {}'.format(args.t, dt))
+                    else:
+                        if not args.wss:
+                            dev = Device(args.t, args.p, init=True)
+                        else:
+                            dev = Device(args.t, args.p, init=True, ssl=True)
+                        print(dev)
+                except Exception as e:
+                    print(e)
+                space = '\n'
         else:
             print('Device: {}'.format(_dev_name))
-        dt = check_device_type(args.t)
-        if not args.i:
-            print('Address: {}, Device Type: {}'.format(args.t, dt))
-        else:
-            if not args.wss:
-                dev = Device(args.t, args.p, init=True)
+            dt = check_device_type(args.t)
+            if not args.i:
+                print('Address: {}, Device Type: {}'.format(args.t, dt))
             else:
-                dev = Device(args.t, args.p, init=True, ssl=True)
-            print(dev)
+                if not args.wss:
+                    dev = Device(args.t, args.p, init=True)
+                else:
+                    dev = Device(args.t, args.p, init=True, ssl=True)
+                print(dev)
         sys.exit()
 
     # SET
     elif args.m == 'set':
         dt = check_device_type(args.t)
-        if vars(args)['@'] is not None:
+        if vars(args)['@']:
             print('Setting {}: {}'.format(dt, entryp))
         else:
             print('Setting {}: {}'.format(dt, _dev_name))
         upydev_ip = args.t
         upydev_pass = args.p
-        if vars(args)['@'] is not None:
-            upydev_name = vars(args)['@']
+        if vars(args)['@']:
+            upydev_name = entryp
         else:
             upydev_name = _dev_name
         upy_conf = {'addr': upydev_ip, 'passwd': upydev_pass, 'name': upydev_name}
@@ -389,4 +405,5 @@ def devicemanagement_action(args, **kargs):
         else:
             see_help(args.m)
 
+    sys.exit()
     sys.exit()

--- a/upydev/devicemanagement.py
+++ b/upydev/devicemanagement.py
@@ -30,7 +30,7 @@ DEVICE_MANAGEMENT_HELP = """
                   of the group and -add option to add devices (indicate a name, ip and the
                   password of each board) or -rm to remove devices (indicated by name)
 
-    - make_sgroup: to make a subset group of an existant group, alias 'mksg'.  Use -f for the name
+    - make_sgroup: to make a subset group of an existing group, alias 'mksg'.  Use -f for the name
                   of the subgroup, -G for the name of parent group and -devs option to indicate the names
                   of the devices to include.
 

--- a/upydev/devicemanagement.py
+++ b/upydev/devicemanagement.py
@@ -48,6 +48,8 @@ VALS_N_ARGS = []
 def address_entry_point(entry_point, group_file='', args=None):
     if group_file == '':
         group_file = 'UPY_G'
+    if args.G is not None and args.G != 'UPY_G':
+        group_file = args.G
     # print(group_file)
     if '{}.config'.format(group_file) not in os.listdir() or args.g:
         group_file = os.path.join(UPYDEV_PATH, group_file)
@@ -67,8 +69,12 @@ def address_entry_point(entry_point, group_file='', args=None):
         elif device_type == 'BleDevice':
             return (dev_address, dev_pass)
     else:
-        print('Device not configured in global group')
-        print("Do '$ upydev gg' to see devices global group")
+        if args.G is not None and args.G != 'UPY_G':
+            print(f'Device {entry_point} not configured in {args.G} group')
+            print(f"Do '$ upydev see {args.G}' to see devices {args.G} group")
+        else:
+            print(f'Device {entry_point} not configured in global group')
+            print("Do '$ upydev gg' to see devices global group")
         sys.exit()
 
 

--- a/upydev/firmwaretools.py
+++ b/upydev/firmwaretools.py
@@ -34,7 +34,7 @@ FIRMWARE_HELP = """
 def get_fw_versions(keyword):
     fw_list = []
     fw_links = []
-    r = requests.get('https://micropython.org/download/all/')
+    r = requests.get(f'https://micropython.org/download/{keyword}/')
     fw_text = [line for line in r.text.split(
         '\n') if keyword in line and any(x in line for x in ['bin', 'dfu', 'zip']) and 'firmware' in line]
     if not fw_text:
@@ -298,7 +298,8 @@ def firmwaretools_action(args, **kargs):
                             print(
                                 'Firmware {} and {} device platform [{}] match, flashing firmware now...'.format(args.f, devname, platform))
                         else:
-                            print('Firmware {} and {} device platform [{}] do NOT match, operation aborted.'.format(args.f, devname, platform))
+                            print('Firmware {} and {} device platform [{}] do NOT match, operation aborted.'.format(
+                                args.f, devname, platform))
                             sys.exit()
                     print('Flashing firmware {} with esptool.py to {} @ {}...'.format(
                         args.f, devname, args.port))
@@ -327,7 +328,8 @@ def firmwaretools_action(args, **kargs):
                             print(
                                 'Firmware {} and {} device platform [{}] match, flashing firmware now...'.format(args.f, devname, platform))
                         else:
-                            print('Firmware {} and {} device platform [{}] do NOT match, operation aborted.'.format(args.f, devname, platform))
+                            print('Firmware {} and {} device platform [{}] do NOT match, operation aborted.'.format(
+                                args.f, devname, platform))
                             sys.exit()
                     print('Flashing firmware {} with esptool.py to {} @ {}...'.format(
                         args.f, devname, args.port))
@@ -365,18 +367,22 @@ def firmwaretools_action(args, **kargs):
                                 print(
                                     'Firmware {} and {} device platform [{}] machine [{}], verison [{}] match, flashing firmware now...'.format(args.f, devname, platform, machine, version))
                             else:
-                                print('Firmware {} and {} device platform [{}] machine [{}], verison [{}] do NOT match, operation aborted.'.format(args.f, devname, platform, machine, version))
+                                print('Firmware {} and {} device platform [{}] machine [{}], verison [{}] do NOT match, operation aborted.'.format(
+                                    args.f, devname, platform, machine, version))
                                 sys.exit()
                         else:
-                            print('Firmware {} and {} device platform [{}] do NOT match, operation aborted.'.format(args.f, devname, platform))
+                            print('Firmware {} and {} device platform [{}] do NOT match, operation aborted.'.format(
+                                args.f, devname, platform))
                             sys.exit()
 
                     print('Enabling DFU mode in pyboard, DO NOT DISCONNECT...')
                     dev.connect()
-                    bs = dev.serial.write(bytes('import pyb;pyb.bootloader()\r', 'utf-8'))
+                    bs = dev.serial.write(
+                        bytes('import pyb;pyb.bootloader()\r', 'utf-8'))
                     time.sleep(0.2)
                     bin_file = args.f
-                    flash_tool = input('Select a tool to flash pydfu.py/dfu-util: (0/1) ')
+                    flash_tool = input(
+                        'Select a tool to flash pydfu.py/dfu-util: (0/1) ')
                     if flash_tool == '0':
                         print('Using pydfu.py...')
                         pydfu_fw_cmd = 'pydfu -u {}'.format(bin_file)

--- a/upydev/gencommands.py
+++ b/upydev/gencommands.py
@@ -11,7 +11,8 @@ AUTHMODE_DICT = {0: 'NONE', 1: 'WEP', 2: 'WPA PSK', 3: 'WPA2 PSK',
 
 KEY_N_ARGS = {'du': ['f', 's'], 'df': ['s'], 'netstat_conn': ['wp'],
               'apconfig': ['ap'], 'i2c_config': ['i2c'],
-              'spi_config': ['spi'], 'set_ntptime': ['utc'], 'tree': ['f']}
+              'spi_config': ['spi'], 'set_ntptime': ['utc'], 'tree': ['f'],
+              'set_hostname': ['f'], 'set_localname': ['f']}
 
 VALS_N_ARGS = ['f', 's', 'wp', 'ap', 'i2c', 'spi', 'utc']
 
@@ -52,7 +53,9 @@ GENERAL_COMMANDS_HELP = """
         - spi_config: to configure the spi pins (see -spi, defaults are SCK=5,MISO=19,MOSI=18,CS=21)
         - set_localtime: to pass host localtime and set upy device rtc
         - set_ntptime: to set rtc from server, (see -utc for time zone)
-        - get_datetime: to get date and time (must be set first, see above commands)"""
+        - get_datetime: to get date and time (must be set first, see above commands)
+        - set_hostname: to set hostname of the device for dhcp service
+        - set_localname: to set localname of the device for ble device gap/advertising name"""
 
 
 def print_sizefile(file_name, filesize, tabs=0):
@@ -112,12 +115,12 @@ def print_filesys_info(filesize):
 
 
 def _dt_format(number):
-        rtc_n = str(number)
-        if len(rtc_n) == 1:
-            rtc_n = "0{}".format(rtc_n)
-            return rtc_n
-        else:
-            return rtc_n
+    rtc_n = str(number)
+    if len(rtc_n) == 1:
+        rtc_n = "0{}".format(rtc_n)
+        return rtc_n
+    else:
+        return rtc_n
 
 
 def _ft_datetime(t_now):
@@ -740,3 +743,35 @@ def gen_command(cmd, *args, **kargs):
     elif cmd == 'gc':
         print(GENERAL_COMMANDS_HELP)
         sys.exit()
+
+    # SET HOSTNAME
+    elif cmd == 'set_hostname':
+        hostname = kargs.pop('f')
+        dev = Device(*args, **kargs)
+        print(f"Setting hostname: {hostname}")
+        dev.cmd(_CMDDICT_['SET_HOSTNAME'].format(f'NAME="{hostname}"'), silent=True)
+        if dev._traceback.decode() in dev.response:
+            try:
+                raise DeviceException(dev.response)
+            except Exception as e:
+                print(e)
+        else:
+            print('Done!')
+        dev.disconnect()
+        return
+
+    # SET LOCALNAME
+    elif cmd == 'set_localname':
+        localname = kargs.pop('f')
+        dev = Device(*args, **kargs)
+        print(f"Setting localname: {localname}")
+        dev.cmd(_CMDDICT_['SET_LOCALNAME'].format(f'NAME="{localname}"'), silent=True)
+        if dev._traceback.decode() in dev.response:
+            try:
+                raise DeviceException(dev.response)
+            except Exception as e:
+                print(e)
+        else:
+            print('Done!')
+        dev.disconnect()
+        return

--- a/upydev/help.config
+++ b/upydev/help.config
@@ -24,5 +24,6 @@
 "pytest-setup": "To set pytest.ini and conftest.py in current working directory to enable selection of specific device with -@ entry point",
 "pytest": "To run upydevice test with pytest, do $ upydev pytest-setup first. e.g. $ upydev pytest mydevicetest.py",
 "tree": "to get directory structure in tree format (requires upysh2.py)",
-"make_sgroup": "to make a subset group of an existing group, alias 'mksg'.  Use -f for the name of the subgroup, -G for the name of parent group and -devs option to indicate the names of the devices to include"
-}
+"make_sgroup": "to make a subset group of an existing group, alias 'mksg'.  Use -f for the name of the subgroup, -G for the name of parent group and -devs option to indicate the names of the devices to include",
+"set_hostname": "to set hostname of the device for dhcp service",
+"set_localname": "to set localname of the device for ble device gap/advertising name"}

--- a/upydev/help.config
+++ b/upydev/help.config
@@ -23,4 +23,6 @@
 "shl": "same as shell",
 "pytest-setup": "To set pytest.ini and conftest.py in current working directory to enable selection of specific device with -@ entry point",
 "pytest": "To run upydevice test with pytest, do $ upydev pytest-setup first. e.g. $ upydev pytest mydevicetest.py",
-"tree": "to get directory structure in tree format (requires upysh2.py)"}
+"tree": "to get directory structure in tree format (requires upysh2.py)",
+"make_sgroup": "to make a subset group of an existant group, alias 'mksg'.  Use -f for the name of the subgroup, -G for the name of parent group and -devs option to indicate the names of the devices to include"
+}

--- a/upydev/help.config
+++ b/upydev/help.config
@@ -24,5 +24,5 @@
 "pytest-setup": "To set pytest.ini and conftest.py in current working directory to enable selection of specific device with -@ entry point",
 "pytest": "To run upydevice test with pytest, do $ upydev pytest-setup first. e.g. $ upydev pytest mydevicetest.py",
 "tree": "to get directory structure in tree format (requires upysh2.py)",
-"make_sgroup": "to make a subset group of an existant group, alias 'mksg'.  Use -f for the name of the subgroup, -G for the name of parent group and -devs option to indicate the names of the devices to include"
+"make_sgroup": "to make a subset group of an existing group, alias 'mksg'.  Use -f for the name of the subgroup, -G for the name of parent group and -devs option to indicate the names of the devices to include"
 }

--- a/upydev/pytest.ini
+++ b/upydev/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 log_cli = 1
 log_cli_level = INFO
-log_cli_format = %(asctime)s [%(name)s] [%(dev)s] : %(message)s
+log_cli_format = %(asctime)s [%(name)s] [%(dev)s] [%(devp)s] : %(message)s

--- a/upydev/rsyncio.py
+++ b/upydev/rsyncio.py
@@ -244,6 +244,7 @@ def synctool(args, dev_name):
                         args.f = file_to_get
                         result = rsyncio.sync_file(args, dev_name)
                         print('Done!')
+                        time_h.sleep(0.2)
                         rsyncio.disconnect()
                     else:
                         if file_exists is False:
@@ -316,6 +317,7 @@ def synctool(args, dev_name):
                                 args.fre = files_to_get
                             result = rsyncio.sync_files(args, dev_name)
                             print('Done!')
+                            time_h.sleep(0.2)
                             rsyncio.disconnect()
                         else:
                             if dir == '':

--- a/upydev/wsio.py
+++ b/upydev/wsio.py
@@ -43,12 +43,13 @@ def do_pg_bar(index, wheel, nb_of_total, speed, time_e, loop_l,
     if index == size_bar:
         l_bloc = "█"
     sys.stdout.write("\033[K")
-    print('▏{}▏{:>2}{:>5} % | {} | {:>5} KB/s | {}/{} s'.format("█" *index + l_bloc  + " "*((size_bar+1) - len("█" *index + l_bloc)),
-                                                                    wheel[index % 4],
-                                                                    int((percentage)*100),
-                                                                    nb_of_total, speed,
-                                                                    str(timedelta(seconds=time_e)).split('.')[0][2:],
-                                                                    str(timedelta(seconds=ett)).split('.')[0][2:]), end='\r')
+    print('▏{}▏{:>2}{:>5} % | {} | {:>5} KB/s | {}/{} s'.format("█" * index + l_bloc + " "*((size_bar+1) - len("█" * index + l_bloc)),
+                                                                wheel[index % 4],
+                                                                int((percentage)*100),
+                                                                nb_of_total, speed,
+                                                                str(timedelta(seconds=time_e)).split(
+                                                                    '.')[0][2:],
+                                                                str(timedelta(seconds=ett)).split('.')[0][2:]), end='\r')
     sys.stdout.flush()
 
 
@@ -290,9 +291,11 @@ def connect_ws(host, port, passwd, websec):
         # print(e, 'Device {} unreachable'.format(devname))
         try:
             if websec:
-                raise DeviceNotFound("WebSocketDevice @ wss://{}:{} is not reachable".format(host, port))
+                raise DeviceNotFound(
+                    "WebSocketDevice @ wss://{}:{} is not reachable".format(host, port))
             else:
-                raise DeviceNotFound("WebSocketDevice @ ws://{}:{} is not reachable".format(host, port))
+                raise DeviceNotFound(
+                    "WebSocketDevice @ ws://{}:{} is not reachable".format(host, port))
         except Exception as e:
             print('ERROR {}'.format(e))
             return False
@@ -350,7 +353,8 @@ def wsfileio(args, file, upyfile, devname, dev=None):
                 abs_src_file = '/{}'.format(src_file)
             print("{}:{} -> {}".format(devname, abs_src_file, dst_file))
             if dev:
-                dev.cmd("import uos, gc; uos.stat('{}')[6]; gc.collect()".format(src_file), silent=True)
+                dev.cmd("import uos, gc; uos.stat('{}')[6]; gc.collect()".format(
+                    src_file), silent=True)
                 size_file_to_get = dev.output
 
     else:
@@ -379,9 +383,11 @@ def wsfileio(args, file, upyfile, devname, dev=None):
                     # print(e, 'Device {} unreachable'.format(devname))
                     try:
                         if args.wss:
-                            raise DeviceNotFound("WebSocketDevice @ wss://{}:{} is not reachable".format(host, port))
+                            raise DeviceNotFound(
+                                "WebSocketDevice @ wss://{}:{} is not reachable".format(host, port))
                         else:
-                            raise DeviceNotFound("WebSocketDevice @ ws://{}:{} is not reachable".format(host, port))
+                            raise DeviceNotFound(
+                                "WebSocketDevice @ ws://{}:{} is not reachable".format(host, port))
                     except Exception as e:
                         print('ERROR {}'.format(e))
                         return False
@@ -414,9 +420,11 @@ def wsfileio(args, file, upyfile, devname, dev=None):
                         # print(e, 'Device {} unreachable'.format(devname))
                         try:
                             if args.wss:
-                                raise DeviceNotFound("WebSocketDevice @ wss://{}:{} is not reachable".format(host, port))
+                                raise DeviceNotFound(
+                                    "WebSocketDevice @ wss://{}:{} is not reachable".format(host, port))
                             else:
-                                raise DeviceNotFound("WebSocketDevice @ ws://{}:{} is not reachable".format(host, port))
+                                raise DeviceNotFound(
+                                    "WebSocketDevice @ ws://{}:{} is not reachable".format(host, port))
                         except Exception as e:
                             print('ERROR {}'.format(e))
                             return False
@@ -430,9 +438,11 @@ def wsfileio(args, file, upyfile, devname, dev=None):
                     # print(e, 'Device {} unreachable'.format(devname))
                     try:
                         if args.wss:
-                            raise DeviceNotFound("WebSocketDevice @ wss://{}:{} is not reachable".format(host, port))
+                            raise DeviceNotFound(
+                                "WebSocketDevice @ wss://{}:{} is not reachable".format(host, port))
                         else:
-                            raise DeviceNotFound("WebSocketDevice @ ws://{}:{} is not reachable".format(host, port))
+                            raise DeviceNotFound(
+                                "WebSocketDevice @ ws://{}:{} is not reachable".format(host, port))
                     except Exception as e:
                         print('ERROR {}'.format(e))
                         return False
@@ -453,7 +463,8 @@ def wsfileio(args, file, upyfile, devname, dev=None):
                         basename = src_file.rsplit("/", 1)[-1]
                         dst_file += basename
                     print("{} -> {}:{}".format(src_file, devname, dst_file))
-                    print('\n{} [{:.2f} KB]'.format(src_file, os.stat(src_file)[6]/1024))
+                    print('\n{} [{:.2f} KB]'.format(
+                        src_file, os.stat(src_file)[6]/1024))
                     try:
                         put_file(ws, src_file, dst_file)
                     except KeyboardInterrupt as e:
@@ -465,9 +476,11 @@ def wsfileio(args, file, upyfile, devname, dev=None):
                         # print(e, 'Device {} unreachable'.format(devname))
                         try:
                             if args.wss:
-                                raise DeviceNotFound("WebSocketDevice @ wss://{}:{} is not reachable".format(host, port))
+                                raise DeviceNotFound(
+                                    "WebSocketDevice @ wss://{}:{} is not reachable".format(host, port))
                             else:
-                                raise DeviceNotFound("WebSocketDevice @ ws://{}:{} is not reachable".format(host, port))
+                                raise DeviceNotFound(
+                                    "WebSocketDevice @ ws://{}:{} is not reachable".format(host, port))
                         except Exception as e:
                             print('ERROR {}'.format(e))
                             return False
@@ -501,6 +514,9 @@ class WebSocketFileIO:
 
 
 def wstool(args, dev_name):
+    if not dev_name:
+        if vars(args)['@'] is not None:
+            dev_name = vars(args)['@']
     if not args.f and not args.fre:
         print('args -f or -fre required:')
         see_help(args.m)
@@ -528,7 +544,8 @@ def wstool(args, dev_name):
                     if args.s:
                         dev = Device(args.t, args.p, init=True, ssl=args.wss,
                                      auth=args.wss)
-                        is_dir_cmd = "import uos, gc; uos.stat('{}')[0] & 0x4000".format(source)
+                        is_dir_cmd = "import uos, gc; uos.stat('{}')[0] & 0x4000".format(
+                            source)
                         is_dir = dev.cmd(is_dir_cmd, silent=True, rtn_resp=True)
                         dev.disconnect()
                         if dev._traceback.decode() in dev.response:
@@ -536,7 +553,8 @@ def wstool(args, dev_name):
                                 raise DeviceException(dev.response)
                             except Exception as e:
                                 print(e)
-                                print('Directory {}:{} does NOT exist'.format(dev_name, source))
+                                print('Directory {}:{} does NOT exist'.format(
+                                    dev_name, source))
                                 result = False
                         else:
                             if is_dir:
@@ -566,7 +584,8 @@ def wstool(args, dev_name):
             # Handle special cases:
             # CASE [cwd]:
             if args.fre[0] == 'cwd' or args.fre[0] == '.':
-                args.fre = [fname for fname in os.listdir('./') if os.path.isfile(fname) and not fname.startswith('.')]
+                args.fre = [fname for fname in os.listdir(
+                    './') if os.path.isfile(fname) and not fname.startswith('.')]
                 print('Files in ./{} to put: '.format(os.getcwd().split('/')[-1]))
             elif '*' in args.fre[0]:
                 args.fre = glob.glob(args.fre[0])
@@ -602,7 +621,8 @@ def wstool(args, dev_name):
                 if args.s:
                     dev = Device(args.t, args.p, init=True, ssl=args.wss,
                                  auth=args.wss)
-                    is_dir_cmd = "import uos, gc; uos.stat('{}')[0] & 0x4000".format(source)
+                    is_dir_cmd = "import uos, gc; uos.stat('{}')[0] & 0x4000".format(
+                        source)
                     is_dir = dev.cmd(is_dir_cmd, silent=True, rtn_resp=True)
                     dev.disconnect()
                     if dev._traceback.decode() in dev.response:
@@ -625,7 +645,8 @@ def wstool(args, dev_name):
                 if result:
                     if args.rst is None:
                         time.sleep(0.1)
-                        dev = Device(args.t, args.p, init=True, ssl=args.wss, auth=args.wss)
+                        dev = Device(args.t, args.p, init=True,
+                                     ssl=args.wss, auth=args.wss)
                         time.sleep(0.2)
                         dev.reset(reconnect=False)
                         time.sleep(0.2)
@@ -647,7 +668,8 @@ def wstool(args, dev_name):
                 if args.s is not None:
                     args.dir = '{}/{}'.format(args.s, args.dir)
                 print('Looking for file in {}:/{} dir'.format(dev_name, args.dir))
-                cmd_str = "import uos; '{}' in uos.listdir('/{}')".format(args.f, args.dir)
+                cmd_str = "import uos; '{}' in uos.listdir('/{}')".format(
+                    args.f, args.dir)
                 dir = '/{}'.format(args.dir)
             try:
                 dev = Device(args.t, args.p, init=True, ssl=args.wss, auth=args.wss)
@@ -661,7 +683,8 @@ def wstool(args, dev_name):
                         result = False
                 else:
                     if file_exists is True:
-                        cmd_str = "import uos; not uos.stat('{}')[0] & 0x4000 ".format(dir + '/' + args.f)
+                        cmd_str = "import uos; not uos.stat('{}')[0] & 0x4000 ".format(
+                            dir + '/' + args.f)
                         is_file = dev.cmd(cmd_str, silent=True, rtn_resp=True)
                 if file_exists is True and is_file:
                     print('Downloading file {} @ {}...'.format(args.f, dev_name))
@@ -682,7 +705,8 @@ def wstool(args, dev_name):
                         print('File Not found in {}:{} directory'.format(dev_name, dir))
                     elif file_exists is True:
                         if is_file is not True:
-                            print('{}:{} is a directory'.format(dev_name, dir + '/' + args.f))
+                            print('{}:{} is a directory'.format(
+                                dev_name, dir + '/' + args.f))
             except DeviceNotFound as e:
                 print('ERROR {}'.format(e))
             except KeyboardInterrupt as e:
@@ -696,7 +720,8 @@ def wstool(args, dev_name):
                 if args.s is not None:
                     args.dir = '{}/{}'.format(args.s, args.dir)
                 print('Looking for files in {}:/{} dir'.format(dev_name, args.dir))
-                cmd_str = "import uos;[file for file in uos.listdir('/{0}') if not uos.stat('/{0}/'+file)[0] & 0x4000]".format(args.dir)
+                cmd_str = "import uos;[file for file in uos.listdir('/{0}') if not uos.stat('/{0}/'+file)[0] & 0x4000]".format(
+                    args.dir)
                 dir = '/{}'.format(args.dir)
             try:
                 dev = Device(args.t, args.p, init=True, ssl=args.wss, auth=args.wss)
@@ -717,7 +742,8 @@ def wstool(args, dev_name):
                             args.fre = file_exists
                         elif '*' in args.fre[0]:
                             start_exp, end_exp = args.fre[0].split('*')
-                            args.fre = [file for file in file_exists if file.startswith(start_exp) and file.endswith(end_exp)]
+                            args.fre = [file for file in file_exists if file.startswith(
+                                start_exp) and file.endswith(end_exp)]
                     if dir == '':
                         dir = '/'
                     print('Files in {}:{} to get: '.format(dev_name, dir))
@@ -738,7 +764,8 @@ def wstool(args, dev_name):
                         print('Downloading files @ {}...'.format(dev_name))
                         # file_to_get = args.f
                         if args.dir is not None:
-                            args.fre = ['/{}/{}'.format(args.dir, file) for file in files_to_get]
+                            args.fre = ['/{}/{}'.format(args.dir, file)
+                                        for file in files_to_get]
                         else:
                             args.fre = files_to_get
                         wsfileio(args, '', '', dev_name, dev=dev)

--- a/upydev_cli/bin/upydev
+++ b/upydev_cli/bin/upydev
@@ -761,7 +761,9 @@ if args.m not in keywords_mode and args.m.startswith('%'):
     see_help(action)
     sys.exit()
 
-_dev_name = None
+_dev_name = vars(args)['@']
+entryp = vars(args)['@']
+
 # @ ENTRY
 if "@" in args.m:
     args.m, entry_point = args.m.split('@')
@@ -818,8 +820,8 @@ if args.t is None:
                     gf, entryp = args.b.split('@')
                     args.t, args.p = address_entry_point(entryp, gf)
             if vars(args)['@'] is not None:
-                    entryp = vars(args)['@']
-                    args.t, args.p = address_entry_point(entryp)
+                entryp = vars(args)['@']
+                args.t, args.p = address_entry_point(entryp)
             if args.apmd:
                 args.t = '192.168.4.1'
             if args.st:

--- a/upydev_cli/bin/upydev
+++ b/upydev_cli/bin/upydev
@@ -22,10 +22,9 @@ import copy
 import time
 import traceback
 import multiprocessing
-import socket
 from argcomplete.completers import ChoicesCompleter
 from ipaddress import ip_address
-from upydevice import check_device_type, Device, DEVGROUP
+from upydevice import check_device_type, Device, DeviceNotFound
 from upydev.helpinfo import HELP_INFO_ARG, see_help
 
 UPYDEV_PATH = upydev.__path__[0]
@@ -46,7 +45,7 @@ def see_groups():
     local_cwd = [group_file.split('.')[0] for group_file in os.listdir(
     ) if '.config' in group_file and group_file not in 'upydev_.config']
     globl_wd = [group_file.split('.')[0] for group_file in os.listdir(
-        upydev.__path__[0]) if '.config' in group_file and group_file not in avoid_files]
+        UPYDEV_PATH) if '.config' in group_file and group_file not in avoid_files]
     return local_cwd + globl_wd
 
 
@@ -57,7 +56,7 @@ def see_global_devs(ws=True, serial=False, ble=False, all=False):
     # globl_wd = [group_file.split('.')[0] for group_file in os.listdir(
     #     upydev.__path__[0]) if '.config' in group_file and group_file not in avoid_files]
     try:
-        with open('{}/UPY_G.config'.format(upydev.__path__[0]), 'r', encoding='utf-8') as group:
+        with open('{}/UPY_G.config'.format(UPYDEV_PATH), 'r', encoding='utf-8') as group:
             devices = json.loads(group.read())
             # print(devices)
         if ws:
@@ -154,7 +153,7 @@ parser.version = '{}: {}'.format(upydev.name, upydev.version)
 parser.add_argument(
     "m", metavar='ACTION', help=helparg, nargs='+').completer = ChoicesCompleter(keywords_mode + keywords_mode_help)
 parser.add_argument("-@", help=help_dv,
-                    required=False).completer = ChoicesCompleter(see_global_devs(all=True))
+                    required=False, nargs='+').completer = ChoicesCompleter(see_global_devs(all=True))
 parser.add_argument("-gg", help='global group flag', required=False,
                     action='store_true')
 parser.add_argument("-ggp", help='global group parallel flag', required=False,
@@ -472,7 +471,7 @@ def see_groups():
     local_cwd = [group_file.split('.')[0] for group_file in os.listdir(
     ) if '.config' in group_file and group_file not in 'upydev_.config']
     globl_wd = [group_file.split('.')[0] for group_file in os.listdir(
-        upydev.__path__[0]) if '.config' in group_file and group_file not in avoid_files]
+        UPYDEV_PATH) if '.config' in group_file and group_file not in avoid_files]
     return local_cwd + globl_wd
 
 
@@ -482,7 +481,7 @@ def address_entry_point(entry_point, group_file=''):
         group_file = 'UPY_G'
     # print(group_file)
     if '{}.config'.format(group_file) not in os.listdir() or args.g:
-        group_file = '{}/{}'.format(upydev.__path__[0], group_file)
+        group_file = os.path.join(UPYDEV_PATH, group_file)
     with open('{}.config'.format(group_file), 'r', encoding='utf-8') as group:
         devices = json.loads(group.read())
         # print(devices)
@@ -534,6 +533,34 @@ def address_entry_point(entry_point, group_file=''):
         print('Device not configured in global group')
         print("Do '$ upydev see -gg' to see devices global group")
         sys.exit()
+
+
+def address_wildcard_entry_point(entry_point, group_file='', args=None):
+    if group_file == '':
+        group_file = 'UPY_G'
+    # print(group_file)
+    if '{}.config'.format(group_file) not in os.listdir() or args.g:
+        group_file = os.path.join(UPYDEV_PATH, group_file)
+    with open('{}.config'.format(group_file), 'r', encoding='utf-8') as group:
+        devices = json.loads(group.read())
+        # print(devices)
+    devs = devices.keys()
+    target_devs = []
+    if '*' in entry_point:
+        if entry_point.startswith('*'):
+            target_devs += [dev for dev in devs if dev.endswith(
+                entry_point.replace('*', ''))]
+        elif entry_point.endswith('*'):
+            target_devs += [dev for dev in devs if dev.startswith(
+                entry_point.replace('*', ''))]
+        elif '*' in entry_point:
+            start, end = entry_point.split('*')
+            target_devs += [dev for dev in devs if dev.startswith(
+                start) and dev.endswith(end)]
+    elif entry_point == 'gg':
+        target_devs += devs
+
+    return target_devs
 #############################################
 
 
@@ -693,7 +720,7 @@ def handle_action(args, exit=True, device_name=None):
     #############################################
 
 
-KW_NOT_GROUP = ['probe', 'scan', 'mksg', 'mak']
+KW_NOT_GROUP = ['probe', 'scan', 'mksg', 'make_sgroup']
 
 
 #############################################
@@ -767,8 +794,54 @@ if args.m not in keywords_mode and args.m.startswith('%'):
     see_help(action)
     sys.exit()
 
-_dev_name = vars(args)['@']
-entryp = vars(args)['@']
+if vars(args)['@']:
+    n_devices = len(vars(args)['@'])
+else:
+    n_devices = 0
+if n_devices == 1:
+    # expand wildcard
+    _dev_name = vars(args)['@'][0]
+    entryp = vars(args)['@'][0]
+    if '*' in entryp or entryp == 'gg':
+        vars(args)['@'] = address_wildcard_entry_point(entryp, args=args)
+        if not vars(args)['@']:
+            raise DeviceNotFound('No device with this name pattern')
+        else:
+            n_devices = len(vars(args)['@'])
+            if n_devices == 1:
+                _dev_name = vars(args)['@'][0]
+                entryp = vars(args)['@'][0]
+            else:
+                args.devs = vars(args)['@']
+                args.gg = True
+                _dev_name = vars(args)['@'][0]
+                entryp = vars(args)['@'][0]
+
+
+elif n_devices == 0:
+    _dev_name = vars(args)['@']
+    entryp = vars(args)['@']
+else:
+    # expand wildcard
+    target_devs = []
+    for dev in vars(args)['@']:
+        if '*' in dev:
+            target_devs += address_wildcard_entry_point(dev, args=args)
+        else:
+            # TODO: allow other groups than global
+            if dev != 'gg':
+                target_devs += [dev]
+            else:
+                # expand group name
+                target_devs += address_wildcard_entry_point(dev, args=args)
+
+    vars(args)['@'] = target_devs
+    args.devs = vars(args)['@']
+    args.gg = True
+    _dev_name = vars(args)['@'][0]
+    entryp = vars(args)['@'][0]
+
+# print(vars(args)['@'])
 
 # @ ENTRY
 if "@" in args.m:
@@ -808,7 +881,7 @@ if args.t is None:
         try:
             file_conf = 'upydev_.config'
             if file_conf not in os.listdir() or args.g:
-                file_conf = '{}/upydev_.config'.format(upydev.__path__[0])
+                file_conf = '{}/upydev_.config'.format(UPYDEV_PATH)
 
             with open(file_conf, 'r') as config_file:
                 upy_conf = json.loads(config_file.read())
@@ -825,8 +898,8 @@ if args.t is None:
                 if "@" in args.b:
                     gf, entryp = args.b.split('@')
                     args.t, args.p = address_entry_point(entryp, gf)
-            if vars(args)['@'] is not None:
-                entryp = vars(args)['@']
+            if vars(args)['@']:
+                entryp = vars(args)['@'][0]
                 args.t, args.p = address_entry_point(entryp)
             if args.apmd:
                 args.t = '192.168.4.1'
@@ -844,7 +917,7 @@ if args.G is not None:
         group_file = args.G
         # print(group_file)
         if '{}.config'.format(group_file) not in os.listdir() or args.g:
-            group_file = '{}/{}'.format(upydev.__path__[0], args.G)
+            group_file = os.path.join(UPYDEV_PATH, args.G)
         # if args.m == 'see':
         #     see()
         #     sys.exit()
@@ -921,12 +994,11 @@ kw_loc = ['run', 'get', 'put', 'timeit', 'install',
           'pytest-setup', 'ble', 'set']
 
 if args.GP is not None:
-    pass
     try:
         group_file = args.GP
         # print(group_file)
         if '{}.config'.format(group_file) not in os.listdir() or args.g:
-            group_file = '{}/{}'.format(upydev.__path__[0], args.GP)
+            group_file = os.path.join(UPYDEV_PATH, args.GP)
 
         print('Sending command to group: {}'.format(group_file.split('/')[-1]))
         with open('{}.config'.format(group_file), 'r', encoding='utf-8') as group:
@@ -935,43 +1007,43 @@ if args.GP is not None:
         devs = devices.keys()
         if args.devs is not None:
             devs = args.devs
-        if args.m not in keywords_mode:
-            dev_list = [Device(devices[dev][0], devices[dev][1],
-                               init=True, name=dev) for dev in devs]
-            devices_group = DEVGROUP(dev_list)
-            cmd = args.m
-            devices_group.cmd_p(cmd, follow=True)
-        else:
-            args_devices = {dev: copy.deepcopy(args) for dev in devs}
-            for dev in devs:
-                args_devices[dev].t = devices[dev][0]
-                args_devices[dev].p = devices[dev][1]
-            # TODO: add args.gf
-            # override print with [device name] ?
-            # redirect ouput to /tmp/dev_x_output
-            # parse output and clean/organized presentation ?
-            process_devices = {dev: multiprocessing.Process(
-                target=handle_action, args=(args_devices[dev], False, dev)) for dev in devs}
+        # if args.m not in keywords_mode:
+        #     dev_list = [Device(devices[dev][0], devices[dev][1],
+        #                        init=True, name=dev) for dev in devs]
+        #     devices_group = DEVGROUP(dev_list)
+        #     cmd = args.m
+        #     devices_group.cmd_p(cmd, follow=True)
+        # else:
+        args_devices = {dev: copy.deepcopy(args) for dev in devs}
+        for dev in devs:
+            args_devices[dev].t = devices[dev][0]
+            args_devices[dev].p = devices[dev][1]
+        # TODO: add args.gf
+        # override print with [device name] ?
+        # redirect ouput to /tmp/dev_x_output
+        # parse output and clean/organized presentation ?
+        process_devices = {dev: multiprocessing.Process(
+            target=handle_action, args=(args_devices[dev], False, dev)) for dev in devs}
 
-            for dev in devs:
-                process_devices[dev].start()
+        for dev in devs:
+            process_devices[dev].start()
 
-            while True:
-                try:
-                    dev_proc_state = [process_devices[dev].is_alive(
-                    ) for dev in devs]
+        while True:
+            try:
+                dev_proc_state = [process_devices[dev].is_alive(
+                ) for dev in devs]
+                if all(state is False for state in dev_proc_state):
+                    time.sleep(0.1)
+                    break
+            except KeyboardInterrupt:
+                while True:
+                    dev_proc_state = [process_devices[dev].is_alive()
+                                      for dev in devs]
                     if all(state is False for state in dev_proc_state):
-                        time.sleep(0.1)
+                        time.sleep(1)
+                        for dev in devs:
+                            process_devices[dev].terminate()
                         break
-                except KeyboardInterrupt:
-                    while True:
-                        dev_proc_state = [process_devices[dev].is_alive()
-                                          for dev in devs]
-                        if all(state is False for state in dev_proc_state):
-                            time.sleep(1)
-                            for dev in devs:
-                                process_devices[dev].terminate()
-                            break
 
     except Exception as e:
         print(traceback.format_exc())

--- a/upydev_cli/bin/upydev
+++ b/upydev_cli/bin/upydev
@@ -477,7 +477,8 @@ def see_groups():
 
 #############################################
 def address_entry_point(entry_point, group_file=''):
-    if group_file == '':
+    group_name = group_file
+    if group_file == '' or group_file is None:
         group_file = 'UPY_G'
     # print(group_file)
     if '{}.config'.format(group_file) not in os.listdir() or args.g:
@@ -530,35 +531,48 @@ def address_entry_point(entry_point, group_file=''):
             dev_pass = devices[entry_point][1]
             return (dev_uuid, dev_pass)
     else:
-        print('Device not configured in global group')
-        print("Do '$ upydev see -gg' to see devices global group")
+        if group_name != '':
+            print(f'Device {entry_point} not configured in {group_name} group')
+            print(f"Do '$ upydev see {group_name}' to see devices {group_name} group")
+        else:
+            print(f'Device {entry_point} not configured in global group')
+            print("Do '$ upydev see -gg' to see devices global group")
         sys.exit()
 
 
-def address_wildcard_entry_point(entry_point, group_file='', args=None):
-    if group_file == '':
-        group_file = 'UPY_G'
-    # print(group_file)
-    if '{}.config'.format(group_file) not in os.listdir() or args.g:
-        group_file = os.path.join(UPYDEV_PATH, group_file)
-    with open('{}.config'.format(group_file), 'r', encoding='utf-8') as group:
-        devices = json.loads(group.read())
-        # print(devices)
-    devs = devices.keys()
+def address_wildcard_entry_point(entry_point, group_file='', exp_entryp=False,
+                                 args=None):
     target_devs = []
-    if '*' in entry_point:
-        if entry_point.startswith('*'):
-            target_devs += [dev for dev in devs if dev.endswith(
-                entry_point.replace('*', ''))]
-        elif entry_point.endswith('*'):
-            target_devs += [dev for dev in devs if dev.startswith(
-                entry_point.replace('*', ''))]
-        elif '*' in entry_point:
-            start, end = entry_point.split('*')
-            target_devs += [dev for dev in devs if dev.startswith(
-                start) and dev.endswith(end)]
-    elif entry_point == 'gg':
-        target_devs += devs
+    try:
+        if group_file == '':
+            group_file = 'UPY_G'
+        if args.G is not None and args.G != 'UPY_G':
+            group_file = args.G
+        if exp_entryp:
+            group_file = exp_entryp
+        # print(group_file)
+        if '{}.config'.format(group_file) not in os.listdir() or args.g:
+            group_file = os.path.join(UPYDEV_PATH, group_file)
+        with open('{}.config'.format(group_file), 'r', encoding='utf-8') as group:
+            devices = json.loads(group.read())
+            # print(devices)
+        devs = devices.keys()
+        if '*' in entry_point:
+            if entry_point.startswith('*'):
+                target_devs += [dev for dev in devs if dev.endswith(
+                    entry_point.replace('*', ''))]
+            elif entry_point.endswith('*'):
+                target_devs += [dev for dev in devs if dev.startswith(
+                    entry_point.replace('*', ''))]
+            elif '*' in entry_point:
+                start, end = entry_point.split('*')
+                target_devs += [dev for dev in devs if dev.startswith(
+                    start) and dev.endswith(end)]
+        elif entry_point == 'gg' or group_file != 'UPY_G':
+            target_devs += devs
+    except Exception as e:
+        # print(e)
+        pass
 
     return target_devs
 #############################################
@@ -798,6 +812,8 @@ if vars(args)['@']:
     n_devices = len(vars(args)['@'])
 else:
     n_devices = 0
+# print(vars(args)['@'])
+
 if n_devices == 1:
     # expand wildcard
     _dev_name = vars(args)['@'][0]
@@ -805,7 +821,38 @@ if n_devices == 1:
     if '*' in entryp or entryp == 'gg':
         vars(args)['@'] = address_wildcard_entry_point(entryp, args=args)
         if not vars(args)['@']:
-            raise DeviceNotFound('No device with this name pattern')
+            try:
+                raise DeviceNotFound('No device with this name pattern')
+            except Exception as e:
+                print(e)
+        else:
+            n_devices = len(vars(args)['@'])
+            if n_devices == 1:
+                _dev_name = vars(args)['@'][0]
+                entryp = vars(args)['@'][0]
+                if args.G:
+                    args.devs = vars(args)['@']
+            else:
+                args.devs = vars(args)['@']
+                if not args.G:
+                    args.gg = True
+                _dev_name = vars(args)['@'][0]
+                entryp = vars(args)['@'][0]
+
+    if entryp not in see_global_devs(all=True):
+        # print(entryp)
+        # check if group file to expand
+        for gconf in glob.glob('*.config'):
+            if entryp == gconf.replace('.config', ''):
+                # fix
+                vars(args)['@'] = address_wildcard_entry_point('gg', entryp,
+                                                               exp_entryp=entryp,
+                                                               args=args)
+        if not vars(args)['@']:
+            try:
+                raise DeviceNotFound('No group with this name pattern')
+            except Exception as e:
+                print(e)
         else:
             n_devices = len(vars(args)['@'])
             if n_devices == 1:
@@ -813,7 +860,8 @@ if n_devices == 1:
                 entryp = vars(args)['@'][0]
             else:
                 args.devs = vars(args)['@']
-                args.gg = True
+                if not args.G:
+                    args.gg = True
                 _dev_name = vars(args)['@'][0]
                 entryp = vars(args)['@'][0]
 
@@ -830,14 +878,44 @@ else:
         else:
             # TODO: allow other groups than global
             if dev != 'gg':
-                target_devs += [dev]
+                if dev not in see_global_devs(all=True):
+                    # check group name in local dir
+                    group_confs = [conf.replace('.config', '') for conf
+                                   in glob.glob('*.config')]
+                    if dev in group_confs:  # expand group
+                        # fix
+                        group_expand = address_wildcard_entry_point('gg', dev,
+                                                                    exp_entryp=dev,
+                                                                    args=args)
+                        # print(group_expand)
+
+                    else:  # device within local group
+                        group_expand = [ldev for ldev in address_wildcard_entry_point(
+                                dev, args=args) if ldev == dev]
+
+                    target_devs += group_expand
+                else:
+                    target_devs += [dev]
             else:
                 # expand group name
                 target_devs += address_wildcard_entry_point(dev, args=args)
 
+    if not target_devs:
+        try:
+            if not args.G:
+                excp_info = """Device/s not configured in global group
+    Do '$ upydev gg' to see devices global group"""
+            else:
+                excp_info = f"""Device/s not configured in {args.G} group
+    Do '$ upydev see {args.G} to see devices {args.G} group"""
+            raise DeviceNotFound(excp_info)
+        except Exception as e:
+            print(e)
+            sys.exit()
     vars(args)['@'] = target_devs
     args.devs = vars(args)['@']
-    args.gg = True
+    if not args.G:
+        args.gg = True
     _dev_name = vars(args)['@'][0]
     entryp = vars(args)['@'][0]
 
@@ -856,6 +934,7 @@ if args.gg:
 if args.ggp:
     # if args.m not in DEBUGGING_ACTIONS:
     args.GP = 'UPY_G'
+    args.G = None
 
 if args.gf:
     if glob.glob('*.config'):
@@ -900,7 +979,7 @@ if args.t is None:
                     args.t, args.p = address_entry_point(entryp, gf)
             if vars(args)['@']:
                 entryp = vars(args)['@'][0]
-                args.t, args.p = address_entry_point(entryp)
+                args.t, args.p = address_entry_point(entryp, args.G)
             if args.apmd:
                 args.t = '192.168.4.1'
             if args.st:
@@ -1000,7 +1079,8 @@ if args.GP is not None:
         if '{}.config'.format(group_file) not in os.listdir() or args.g:
             group_file = os.path.join(UPYDEV_PATH, args.GP)
 
-        print('Sending command to group: {}'.format(group_file.split('/')[-1]))
+        print('Sending command in parallel to group: {}'.format(
+            group_file.split('/')[-1]))
         with open('{}.config'.format(group_file), 'r', encoding='utf-8') as group:
             devices = json.loads(group.read())
             # print(devices)

--- a/upydev_cli/bin/upydev
+++ b/upydev_cli/bin/upydev
@@ -128,7 +128,7 @@ keywords_mode = ['put', 'get', 'fget', 'cmd', 'config', 'info', 'netinfo',
                  'pytest-setup', 'check', 'ble', 'brepl', 'set', 'gg', 'probe',
                  'scan', 'repl', 'rpl', 'shell', 'shl', 'list', 'latest',
                  'rsa', 'wr', 'keygen', 'mkg', 'mkgroup', 'mgg', 'mggroup', 'tree',
-                 'backup', 'rsync']
+                 'backup', 'rsync', 'make_sgroup', 'mksg']
 
 keywords_mode_help = ['%' + kw for kw in keywords_mode]
 help_actions = ['help', 'h', 'dm', 'fio', 'fw', 'kg', 'rp', 'sh', 'db', 'gp',
@@ -332,8 +332,8 @@ argcomplete.autocomplete(parser)
 args = parser.parse_args()
 
 multiple_args_fio = ['put', 'get', 'fget', 'install', 'dsync', 'run', 'timeit',
-                     'pytest', 'make_group', 'mg_group', 'du', 'tree', 'rsync',
-                     'docs', 'udocs', 'mdocs']
+                     'pytest', 'make_group', 'mg_group', 'make_sgroup', 'du', 'tree',
+                     'rsync', 'docs', 'udocs', 'mdocs']
 multiple_args_fw = ['fwr', 'flash', 'mpyx']
 
 if len(args.m) == 1:
@@ -375,6 +375,9 @@ elif len(args.m) == 2:
     elif args.m == 'mggroup' or args.m == 'mgg':
         args.m = 'mg_group'
         args.G = second_arg
+    elif args.m == 'mksg':
+        args.m = 'make_sgroup'
+        args.f = second_arg
     elif args.m == 'see' or args.m == 'probe':
         args.G = second_arg
 
@@ -395,7 +398,7 @@ elif len(args.m) > 2:
 # DEVICE MANAGEMENT ACTIONS
 
 DEVICE_MANAGEMENT_ACTIONS = ['config', 'check', 'set', 'make_group',
-                             'mg_group', 'gg', 'see']
+                             'mg_group', 'gg', 'see', 'make_sgroup']
 
 # FIRMWARE ACTIONS
 
@@ -687,7 +690,7 @@ def handle_action(args, exit=True, device_name=None):
     #############################################
 
 
-KW_NOT_GROUP = ['probe', 'scan']
+KW_NOT_GROUP = ['probe', 'scan', 'mksg', 'mak']
 
 
 #############################################
@@ -772,11 +775,11 @@ if "@" in args.m:
 
 if args.gg:
     # if args.m not in DEBUGGING_ACTIONS:
-        args.G = 'UPY_G'
+    args.G = 'UPY_G'
 
 if args.ggp:
     # if args.m not in DEBUGGING_ACTIONS:
-        args.GP = 'UPY_G'
+    args.GP = 'UPY_G'
 
 if args.gf:
     if glob.glob('*.config'):

--- a/upydev_cli/bin/upydev
+++ b/upydev_cli/bin/upydev
@@ -128,7 +128,8 @@ keywords_mode = ['put', 'get', 'fget', 'cmd', 'config', 'info', 'netinfo',
                  'pytest-setup', 'check', 'ble', 'brepl', 'set', 'gg', 'probe',
                  'scan', 'repl', 'rpl', 'shell', 'shl', 'list', 'latest',
                  'rsa', 'wr', 'keygen', 'mkg', 'mkgroup', 'mgg', 'mggroup', 'tree',
-                 'backup', 'rsync', 'make_sgroup', 'mksg']
+                 'backup', 'rsync', 'make_sgroup', 'mksg', 'set_localname',
+                 'set_hostname']
 
 keywords_mode_help = ['%' + kw for kw in keywords_mode]
 help_actions = ['help', 'h', 'dm', 'fio', 'fw', 'kg', 'rp', 'sh', 'db', 'gp',
@@ -333,7 +334,7 @@ args = parser.parse_args()
 
 multiple_args_fio = ['put', 'get', 'fget', 'install', 'dsync', 'run', 'timeit',
                      'pytest', 'make_group', 'mg_group', 'make_sgroup', 'du', 'tree',
-                     'rsync', 'docs', 'udocs', 'mdocs']
+                     'rsync', 'docs', 'udocs', 'mdocs', 'set_hostname', 'set_localname']
 multiple_args_fw = ['fwr', 'flash', 'mpyx']
 
 if len(args.m) == 1:
@@ -380,6 +381,8 @@ elif len(args.m) == 2:
         args.f = second_arg
     elif args.m == 'see' or args.m == 'probe':
         args.G = second_arg
+    elif args.m == 'set_hostname' or args.m == 'set_localname':
+        args.f = second_arg
 
 elif len(args.m) > 2:
     rest_args = args.m[1:]
@@ -435,7 +438,7 @@ GENERAL_COMMANDS = ['info', 'id', 'upysh', 'reset', 'kbi',
                     'netstat_off', 'netstat_conn', 'netstat', 'ap_on',
                     'ap_off', 'apstat', 'apconfig', 'apscan', 'i2c_config',
                     'i2c_scan', 'spi_config', 'set_localtime', 'set_ntptime',
-                    'get_datetime', 'gc']
+                    'get_datetime', 'gc', 'set_hostname', 'set_localname']
 # WLAN COMMANDS
 
 WLAN_UTILS_COMMANDS = ['wlan_init', 'wsta_config', 'wap_config', 'wsta_conn',

--- a/upyutils/ble_uart_peripheral.py
+++ b/upyutils/ble_uart_peripheral.py
@@ -3,9 +3,12 @@
 import bluetooth
 from ble_advertising import advertising_payload
 import time
-
 from micropython import const
 
+try:
+    from localname import NAME as LOCALNAME
+except Exception:
+    LOCALNAME = None
 _IRQ_CENTRAL_CONNECT = const(1)
 _IRQ_CENTRAL_DISCONNECT = const(2)
 _IRQ_GATTS_WRITE = const(3)
@@ -25,7 +28,12 @@ class BLEUART:
     def __init__(self, ble, name='mpy-uart', rxbuf=512, uuid=''):
         self._ble = ble
         self._ble.active(True)
-        self._ble.config(gap_name='ESP32@{}'.format(uuid), mtu=515, rxbuf=512)
+        if LOCALNAME:
+            _gap_name = LOCALNAME
+            name = LOCALNAME
+        else:
+            _gap_name = 'ESP32@{}'.format(uuid)
+        self._ble.config(gap_name=_gap_name, mtu=515, rxbuf=512)
         self._ble.irq(self._irq)
         ((self._tx_handle, self._rx_handle,),
          ) = self._ble.gatts_register_services((_UART_SERVICE,))

--- a/upyutils/mqtt_client.py
+++ b/upyutils/mqtt_client.py
@@ -28,7 +28,7 @@ class mqtt_client(MQTTClient):
         self.port = port
         super().__init__(self.id, self.broker_addrss, self.port,
                          user=self.user, password=self.passwd,
-                         keepalive=0, ssl=False, ssl_params={})
+                         keepalive=keepalive, ssl=False, ssl_params={})
 
     def callback(self, topic, message):
         msg = message.decode('utf-8')


### PR DESCRIPTION
## Added
- `rssi` command in shell repls to get RSSI value (Wifi or Ble)
- `make_sgroup` / `mksg` command to create a subgroup of an existing group of devices.
- `set_hostname` command to set hostname of the device for dhcp service (needs *wpa_supplicant.py*)
- `set_localname` command to set localname of the device for ble gap/advertising name (needs *ble_uart_peripheral.py*)
- Now `-@` option accepts multiple devices, names with `*` wildcard or global group `gg` or other group names, e.g. `upydev check -i -@ esp\* dev{1..4} mytestgroup`
will expand to all devices that start with `esp` , `dev1 dev2 dev3 dev4` and devices configured in `mytestgroup`
## Fix
- `firmwaretools.get_fw_versions` update after `micropython.org\all` not working anymore.
- fix device name instead of `None` in `put`, `get`, `fget`, `dsync` in `sslweb_repl` with `-nem` mode enabled.
- fix `fget` disconnection error.